### PR TITLE
Mark delinquencies - Skip Nonces

### DIFF
--- a/contracts/L1.sol
+++ b/contracts/L1.sol
@@ -41,20 +41,30 @@ contract L1Contract {
             escrowHash == ticket.escrowHash,
             "The preimage must match the escrow hash on the ticket"
         );
-
-        require(
-            ticket.nonce == nonces[ticket.sender] + 1,
-            "Ticket nonce must be the next available nonce"
-        );
+        
+        // "register" the skipped nonce
+        if (ticket.delinquentValue > 0) {
+            // set aside outstanding balance for missing nonce
+            providers[ticket.sender].outstanding[
+                providers[ticket.sender].nonce
+            ] = ticket.delinquentValue;
+            // reduce the 'global' balance by the same
+            providers[ticket.sender].balance -= ticket.delinquentValue;
+            // skip this nonce
+            providers[ticket.sender].nonce++;
+        }
 
         require(
             ticketSigner == ticket.sender,
             "Ticket is not signed by sender"
         );
         require(
+            // todo: OR ticken.nonce is in providers[tiken.sender].outstanding
             ticket.nonce == providers[ticket.sender].nonce + 1,
             "Ticket nonce must be the next available nonce"
         );
+        require(
+            // todo: OR tocket.value === providers[ticket.sender][ticket.reciever]
             providers[ticket.sender].balance >= ticket.value,
             "Sender does not have enough funds"
         );
@@ -67,6 +77,6 @@ contract L1Contract {
 
     function deposit() public payable {
         // TODO: Overflow check?
-        balances[msg.sender] += msg.value;
+        providers[msg.sender].balance += msg.value;
     }
 }

--- a/contracts/L1.sol
+++ b/contracts/L1.sol
@@ -4,10 +4,8 @@ pragma solidity ^0.8.10;
 import "./common.sol";
 
 contract L1Contract {
-    /// This is a record of the highest nonce per sender.
-    mapping(address => uint256) nonces;
-    /// This is a record of funds  allocated to different senders.
-    mapping(address => uint256) balances;
+    /// This is a set of accounting records for each liquidity provider
+    mapping(address => Provider) providers;
 
     /// Claims multiple tickets.
     function claimTickets(
@@ -54,14 +52,17 @@ contract L1Contract {
             "Ticket is not signed by sender"
         );
         require(
-            balances[ticket.sender] >= ticket.value,
+            ticket.nonce == providers[ticket.sender].nonce + 1,
+            "Ticket nonce must be the next available nonce"
+        );
+            providers[ticket.sender].balance >= ticket.value,
             "Sender does not have enough funds"
         );
 
-        nonces[ticket.sender]++;
+        providers[ticket.sender].nonce++;
         ticket.receiver.transfer(ticket.value);
         // TODO: Underflow check?
-        balances[msg.sender] -= ticket.value;
+        providers[ticket.sender].balance -= ticket.value;
     }
 
     function deposit() public payable {

--- a/contracts/L2.sol
+++ b/contracts/L2.sol
@@ -102,6 +102,14 @@ contract L2Contract {
         WithdrawalTicket calldata ticket,
         Signature calldata ticketSignature
     ) public {
+        bytes32 ticketHash = keccak256(abi.encode(ticket));
+        address ticketSigner = recoverSigner(ticketHash, ticketSignature);
+
+        require(
+            ticket.sender == ticketSigner,
+            "The ticket must be signed by the sender."
+        );
+
         // sender is bumping nonce because of an unclaimed  L1 ticket
         if (ticket.delinquentValue! != 0) {
             nonces[ticket.sender]++;
@@ -112,13 +120,6 @@ contract L2Contract {
             "The ticket must use the next nonce."
         );
 
-        bytes32 ticketHash = keccak256(abi.encode(ticket));
-        address ticketSigner = recoverSigner(ticketHash, ticketSignature);
-
-        require(
-            ticket.sender == ticketSigner,
-            "The ticket must be signed by the sender."
-        );
 
         nonces[ticket.sender]++;
         ticketCommitments[ticket.sender][ticket.nonce] = ticketHash;

--- a/contracts/L2.sol
+++ b/contracts/L2.sol
@@ -102,6 +102,11 @@ contract L2Contract {
         WithdrawalTicket calldata ticket,
         Signature calldata ticketSignature
     ) public {
+        // sender is bumping nonce because of an unclaimed  L1 ticket
+        if (ticket.delinquentValue! != 0) {
+            nonces[ticket.sender]++;
+        }
+
         require(
             ticket.nonce == nonces[ticket.sender] + 1,
             "The ticket must use the next nonce."

--- a/contracts/common.sol
+++ b/contracts/common.sol
@@ -7,6 +7,15 @@ struct Signature {
     uint8 v;
 }
 
+struct Provider {
+    // a map of outstanding ticket nonces, and the values associated with each
+    mapping(uint256 => uint256) outstanding;
+    // the nonce of the last claimed ticket
+    uint256 nonce;
+    // the balance available to the current nonce
+    uint balance;
+}
+
 /// This represents a request to move ETH on L1 from sender to receiver.
 struct WithdrawalTicket {
     /// The amount of value to be transferred.

--- a/contracts/common.sol
+++ b/contracts/common.sol
@@ -28,4 +28,7 @@ struct WithdrawalTicket {
     address sender;
     /// The hash for the funds locked in escrow for this ticket.
     bytes32 escrowHash;
+
+    /// The "missing" withdrawal balance from ticet {nonce-1}. Usally 0.
+    uint256 delinquentValue;
 }


### PR DESCRIPTION
This is a (slightly) more complete version of what I had posted to Notion. Basic idea:

- Alice is delinquent (hasn't withdrawn from L1), but Bob has Carol waiting in line.
- ... so Bob signs a ticket for Carol which includes the size of Alice's delinquent ticket
- chains L1 and L2 read this delinquency report & skip the nonce
- chain L1 sets aside the outstanding balance specifically for Alice to claim out-of-order

**Pros:**
- allows Bob to progress in the face of absent Alices
- Allows slow-Alice to still use her L1 ticket even if she's late
- allows for some sort of slashing on Alice, so that Bob can recoup the extra gas costs incurred when he redeemed Carol's ticket on L1

**Cons:**
- more on-chain storage, but Bob can manage this storage as he sees fit by reclaiming delinquent tickets on L1 after they time out
- potential for mis-hap timing issues - Bob may issue a ticket to Carol, which marks Alice as delinquent, at the same time that he observes Alice claiming on L1. I think these are gas-cost issues only, and not security / liveness

**todo:**
- this PR didn't include any of the L1 expiration-time work, which is still required
- this PR doesn't allow for Alice to make her late claim. See `todo`s in `L1.claimTicket`

Recommend reading **per-commit**