### PR TITLE
Update TSConfig to include tests and hardhat config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
-  "include": ["src"],
+  "include": ["src", "test"],
+  "files": ["./hardhat.config.ts"],
   "exclude": [],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */


### PR DESCRIPTION
This fixes the "Hardhat has no exported member ethers" that shows up in vs code and prevents vs code from autocompleting `ether` methods.

![image](https://user-images.githubusercontent.com/1620336/144298872-5119038b-d93c-4614-826f-9ce9fbf6d6ee.png)

