### PR TITLE
Sanity-check test works through 2 batches

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Current test",
+      "type": "node",
+      "request": "launch",
+      "args": ["node_modules/.bin/hardhat", "test", "${relativeFile}"],
+      "cwd": "${workspaceRoot}",
+      "protocol": "inspector",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "env": {
+        "NODE_ENV": "test"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The sanity-check test tests:
1. 2 customers register swaps.
2. Liquidity provider authorizes and claims swaps on L1 and L2.
3. The above is repeated.

This PR also adds `launch.json` so that the test can be debugged in VS Code.