### PR TITLE
Require non-overlapping batches

### DIFF
--- a/contracts/l2.sol
+++ b/contracts/l2.sol
@@ -41,6 +41,7 @@ contract L2 is SignatureChecker {
     // `batches` is used to record the fact that tickets with nonce between startingNonce and startingNonce + numTickets-1 are authorized, claimed or returned.
     // Indexed by nonce
     mapping(uint256 => Batch) batches;
+    uint256 nextNonceToAuthorize = 0;
 
     // TODO: check payment amount
     function depositOnL2(L2Deposit calldata deposit) public payable {
@@ -91,6 +92,7 @@ contract L2 is SignatureChecker {
         );
         uint256 earliestTimestamp = registeredTickets[first].timestamp;
 
+        require(nextNonceToAuthorize == first, "Batches must be gapless");
         require(
             recoverSigner(message, signature) == lpAddress,
             "Must be signed by liquidity provider"
@@ -107,6 +109,7 @@ contract L2 is SignatureChecker {
             latestTimestamp: registeredTickets[last].timestamp,
             status: BatchStatus.Pending
         });
+        nextNonceToAuthorize = last + 1;
     }
 
     function claimL2Funds(uint256 first) public {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
+    "@types/chai-as-promised": "^7.1.4",
     "@types/mocha": "^9.0.0",
     "chai": "^4.3.4",
+    "chai-as-promised": "^7.1.1",
     "eth-gas-reporter": "^0.2.22",
     "ethereum-waffle": "^3.4.0",
     "hardhat": "^2.6.7",

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -97,7 +97,7 @@ it("Successfull e2e swap", async () => {
   await swap(2, 8);
 });
 
-it.only("Unable to authorize overlapping batches", async () => {
+it("Unable to authorize overlapping batches", async () => {
   await swap(0, 10);
   await expect(swap(1, 9)).to.be.rejectedWith("Batches must be gapless");
 });

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -64,6 +64,7 @@ async function swap(trustedNonce: number, trustedAmount: number) {
   const signature = signData(hashTickets(ticketsWithIndex), lpPK);
   await waitForTx(
     lpL2.authorizeWithdrawal(trustedNonce, trustedNonce + 1, signature, {
+      // TODO: remove this after addressing https://github.com/statechannels/SAFE-protocol/issues/70
       gasLimit: 30_000_000,
     }),
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -942,6 +942,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/chai-as-promised@npm:^7.1.4":
+  version: 7.1.4
+  resolution: "@types/chai-as-promised@npm:7.1.4"
+  dependencies:
+    "@types/chai": "*"
+  checksum: bb974e77e0357fcc9a01f4b46eb1d3d6a40621a479654fa17539890cd59635faf9b860b8c3851f638d1e239404b1dc8e7ab1305f26dec43e19cce6796e01fe48
+  languageName: node
+  linkType: hard
+
 "@types/chai@npm:*":
   version: 4.2.22
   resolution: "@types/chai@npm:4.2.22"
@@ -2760,6 +2769,17 @@ __metadata:
   version: 0.12.0
   resolution: "caseless@npm:0.12.0"
   checksum: b43bd4c440aa1e8ee6baefee8063b4850fd0d7b378f6aabc796c9ec8cb26d27fb30b46885350777d9bd079c5256c0e1329ad0dc7c2817e0bb466810ebb353751
+  languageName: node
+  linkType: hard
+
+"chai-as-promised@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "chai-as-promised@npm:7.1.1"
+  dependencies:
+    check-error: ^1.0.2
+  peerDependencies:
+    chai: ">= 2.1.2 < 5"
+  checksum: 7262868a5b51a12af4e432838ddf97a893109266a505808e1868ba63a12de7ee1166e9d43b5c501a190c377c1b11ecb9ff8e093c89f097ad96c397e8ec0f8d6a
   languageName: node
   linkType: hard
 
@@ -4681,8 +4701,10 @@ __metadata:
     "@openzeppelin/contracts": ^4.3.3
     "@typechain/ethers-v5": ^8.0.3
     "@typechain/hardhat": ^3.0.0
+    "@types/chai-as-promised": ^7.1.4
     "@types/mocha": ^9.0.0
     chai: ^4.3.4
+    chai-as-promised: ^7.1.1
     eth-gas-reporter: ^0.2.22
     ethereum-waffle: ^3.4.0
     ethers: ^5.0.0


### PR DESCRIPTION
This PR introduces gapless batches. When a liquidity provider authorizes a batch, the first ticket in the batch must have a nonce following the last authorized nonce.