### PR TITLE
Add refundOnFraud

### DIFF
--- a/contracts/l2.sol
+++ b/contracts/l2.sol
@@ -144,7 +144,7 @@ contract L2 is SignatureChecker {
         uint256 fraudStartNonce,
         uint256 fraudDelta,
         Ticket[] calldata fraudTickets,
-        Signature calldata signature
+        Signature calldata fraudSignature
     ) public {
         isProvableFraud(
             honestStartNonce,
@@ -152,7 +152,7 @@ contract L2 is SignatureChecker {
             fraudStartNonce,
             fraudDelta,
             fraudTickets,
-            signature
+            fraudSignature
         );
 
         Batch memory batch = batches[honestStartNonce];
@@ -194,7 +194,7 @@ contract L2 is SignatureChecker {
         uint256 fraudStartNonce,
         uint256 fraudDelta,
         Ticket[] calldata fraudTickets,
-        Signature calldata signature
+        Signature calldata fraudSignature
     ) private view {
         bytes32 message = keccak256(
             abi.encode(TicketsWithIndex(fraudStartNonce, fraudTickets))
@@ -204,7 +204,7 @@ contract L2 is SignatureChecker {
             "Honest and fraud indices must match"
         );
         require(
-            recoverSigner(message, signature) == lpAddress,
+            recoverSigner(message, fraudSignature) == lpAddress,
             "Must be signed by liquidity provider"
         );
 

--- a/contracts/l2.sol
+++ b/contracts/l2.sol
@@ -140,7 +140,7 @@ contract L2 is SignatureChecker {
 
     /**
      * @notice Prove fraud and refund all tickets in the fraudulent batch
-     * @param honestStartNonce Index of the first ticket in the honest batch OR first unauthorized nonce
+     * @param honestStartNonce Index of the first ticket in the honest batch
      * @param honestDelta Offset from honestStartNonce to the honest ticket
      * @param fraudStartNonce Index of the first ticket in the fraudulent batch
      * @param fraudDelta Offset from fraudStartNonce to the fraudulent ticket
@@ -166,24 +166,6 @@ contract L2 is SignatureChecker {
 
         Batch memory batch = batches[honestStartNonce];
         uint256 lastNonce = honestStartNonce + fraudDelta;
-
-        // Below checks whether "batch" is null (since there is never a batch with numTickets == 0)
-        // If the ticket has never been authorized, it is not part of any batch
-        // In this case, a new batch is created that includes the ticket
-        if (batch.numTickets == 0) {
-            require(
-                lastNonce >= nextNonceToAuthorize,
-                "The nonce must not be authorized"
-            );
-            (batch, ) = createBatch(
-                nextNonceToAuthorize,
-                honestStartNonce + fraudDelta
-            );
-            batches[nextNonceToAuthorize] = batch;
-            batch.status = BatchStatus.Authorized;
-            nextNonceToAuthorize = lastNonce + 1;
-        }
-
         require(
             batch.status == BatchStatus.Authorized,
             "Batch status must be Authorized"

--- a/contracts/l2.sol
+++ b/contracts/l2.sol
@@ -15,11 +15,11 @@ struct L2Deposit {
     address l1Recipient;
 }
 
-// Pending: all tickets in this batch are authorized but not claimed
+// Authorized: all tickets in this batch are authorized but not claimed
 // Claimed: all tickets in this batch are claimed
 // Returned: all tickets in this batch have been returned, due to inactivity or provable fraud.
 enum BatchStatus {
-    Pending,
+    Authorized,
     Claimed,
     Returned
 }
@@ -104,7 +104,7 @@ contract L2 is SignatureChecker {
             numTickets: last - first + 1,
             total: total,
             authorizedAt: block.timestamp,
-            status: BatchStatus.Pending
+            status: BatchStatus.Authorized
         });
         nextNonceToAuthorize = last + 1;
     }
@@ -112,8 +112,8 @@ contract L2 is SignatureChecker {
     function claimL2Funds(uint256 first) public {
         Batch memory batch = batches[first];
         require(
-            batch.status == BatchStatus.Pending,
-            "Batch status must be pending"
+            batch.status == BatchStatus.Authorized,
+            "Batch status must be Authorized"
         );
         require(
             block.timestamp > batch.authorizedAt + safetyDelay,

--- a/contracts/l2.sol
+++ b/contracts/l2.sol
@@ -164,13 +164,12 @@ contract L2 is SignatureChecker {
             fraudSignature
         );
 
-        Batch memory batch = batches[honestStartNonce];
-        uint256 lastNonce = honestStartNonce + fraudDelta;
         require(
-            batch.status == BatchStatus.Authorized,
+            batches[honestStartNonce].status == BatchStatus.Authorized,
             "Batch status must be Authorized"
         );
 
+        uint256 lastNonce = honestStartNonce + fraudDelta;
         for (uint256 i = honestStartNonce; i <= lastNonce; i++) {
             (bool sent, ) = tickets[i].l1Recipient.call{
                 value: tickets[i].value

--- a/contracts/l2.sol
+++ b/contracts/l2.sol
@@ -17,11 +17,11 @@ struct L2Deposit {
 
 // Authorized: all tickets in this batch are authorized but not claimed
 // Claimed: all tickets in this batch are claimed
-// Returned: all tickets in this batch have been returned, due to inactivity or provable fraud.
+// Refunded: all tickets in this batch have been refunded, due to inactivity or provable fraud.
 enum BatchStatus {
     Authorized,
     Claimed,
-    Returned
+    Refunded
 }
 
 struct Batch {
@@ -37,7 +37,7 @@ uint256 constant safetyDelay = 60;
 
 contract L2 is SignatureChecker {
     Ticket[] public tickets;
-    // `batches` is used to record the fact that tickets with nonce between startingNonce and startingNonce + numTickets-1 are authorized, claimed or returned.
+    // `batches` is used to record the fact that tickets with nonce between startingNonce and startingNonce + numTickets-1 are authorized, claimed or refunded.
     // Indexed by nonce
     mapping(uint256 => Batch) batches;
     uint256 nextNonceToAuthorize = 0;
@@ -185,7 +185,7 @@ contract L2 is SignatureChecker {
             require(sent, "Failed to send Ether");
         }
 
-        batches[honestStartNonce].status = BatchStatus.Returned;
+        batches[honestStartNonce].status = BatchStatus.Refunded;
     }
 
     function isProvableFraud(

--- a/contracts/l2.sol
+++ b/contracts/l2.sol
@@ -138,6 +138,15 @@ contract L2 is SignatureChecker {
         require(sent, "Failed to send Ether");
     }
 
+    /**
+     * @notice Prove fraud and refund all tickets in the fraudulent batch
+     * @param honestStartNonce Index of the first ticket in the honest batch OR first unauthorized nonce
+     * @param honestDelta Offset from honestStartNonce to the honest ticket
+     * @param fraudStartNonce Index of the first ticket in the fraudulent batch
+     * @param fraudDelta Offset from fraudStartNonce to the fraudulent ticket
+     * @param fraudTickets All tickets in the fraudulent batch
+     * @param fraudSignature Signature on the fraudulent batch
+     */
     function refundOnFraud(
         uint256 honestStartNonce,
         uint256 honestDelta,
@@ -158,8 +167,9 @@ contract L2 is SignatureChecker {
         Batch memory batch = batches[honestStartNonce];
         uint256 lastNonce = honestStartNonce + fraudDelta;
 
-        // If the ticket has never been authorized, it is not part of any batch
         // Below checks whether "batch" is null (since there is never a batch with numTickets == 0)
+        // If the ticket has never been authorized, it is not part of any batch
+        // In this case, a new batch is created that includes the ticket
         if (batch.numTickets == 0) {
             require(
                 lastNonce >= nextNonceToAuthorize,
@@ -173,9 +183,10 @@ contract L2 is SignatureChecker {
             batch.status = BatchStatus.Authorized;
             nextNonceToAuthorize = lastNonce + 1;
         }
+
         require(
             batch.status == BatchStatus.Authorized,
-            "Batch status must be authorized"
+            "Batch status must be Authorized"
         );
 
         for (uint256 i = honestStartNonce; i <= lastNonce; i++) {

--- a/contracts/l2.sol
+++ b/contracts/l2.sol
@@ -42,7 +42,6 @@ contract L2 is SignatureChecker {
     mapping(uint256 => Batch) batches;
     uint256 nextNonceToAuthorize = 0;
 
-    // TODO: check payment amount
     function depositOnL2(L2Deposit calldata deposit) public payable {
         uint256 amountAvailable = deposit.trustedAmount;
         uint256 trustedNonce = deposit.trustedNonce;

--- a/contracts/l2.sol
+++ b/contracts/l2.sol
@@ -170,9 +170,8 @@ contract L2 is SignatureChecker {
         Ticket memory correctTicket = tickets[honestStartNonce + honestDelta];
         Ticket memory fraudTicket = fraudTickets[fraudDelta];
         require(
-            correctTicket.l1Recipient != fraudTicket.l1Recipient ||
-                correctTicket.value != fraudTicket.value ||
-                correctTicket.timestamp != fraudTicket.timestamp,
+            keccak256(abi.encode(correctTicket)) !=
+                keccak256(abi.encode(fraudTicket)),
             "Honest and fraud tickets must differ"
         );
 

--- a/contracts/l2.sol
+++ b/contracts/l2.sol
@@ -164,13 +164,14 @@ contract L2 is SignatureChecker {
             fraudSignature
         );
 
+        Batch memory honestBatch = batches[honestStartNonce];
+
         require(
-            batches[honestStartNonce].status == BatchStatus.Authorized,
+            honestBatch.status == BatchStatus.Authorized,
             "Batch status must be Authorized"
         );
 
-        uint256 lastNonce = honestStartNonce + fraudDelta;
-        for (uint256 i = honestStartNonce; i <= lastNonce; i++) {
+        for (uint256 i = honestStartNonce; i < honestBatch.numTickets; i++) {
             (bool sent, ) = tickets[i].l1Recipient.call{
                 value: tickets[i].value
             }("");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,10 @@ export function hashTickets(ticketsWithIndex: TicketsWithIndex): string {
 
 // TODO: This was stolen from our old nitro protocol repo
 // Probably a cleaner way of signing it
-export function signData(hashedData: string, privateKey: string): any {
+export function signData(
+  hashedData: string,
+  privateKey: string,
+): ethers.Signature {
   const signingKey = new ethers.utils.SigningKey(privateKey);
   const hashedMessage = ethers.utils.hashMessage(
     ethers.utils.arrayify(hashedData),

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -155,7 +155,7 @@ it("Able to prove fraud", async () => {
         gasLimit,
       },
     ),
-  ).to.be.rejectedWith("Batch status must be authorized");
+  ).to.be.rejectedWith("Batch status must be Authorized");
 
   /**
    * Fraud committed after a batch is authorized. The setup is:

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -115,7 +115,7 @@ it("Unable to authorize overlapping batches", async () => {
   await expect(swap(1, 9)).to.be.rejectedWith("Batches must be gapless");
 });
 
-it("Able to prove fraud", async () => {
+it("Handles a fraud proofs", async () => {
   /**
    * Fraud instance 1. The liquidity provider signs a batch of tickets with the
    * second ticket's l1Recipient switched to LP's address

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -135,17 +135,19 @@ it("Able to prove fraud", async () => {
   const fraudSignature = signData(hashTickets(ticketsWithIndex), lpPK);
 
   // Successfully prove fraud
-  await customer2L2.refundOnFraud(
-    0,
-    1,
-    0,
-    1,
-    [ticket, fraudTicket],
-    fraudSignature,
+  await waitForTx(
+    customer2L2.refundOnFraud(
+      0,
+      1,
+      0,
+      1,
+      [ticket, fraudTicket],
+      fraudSignature,
+    ),
   );
 
   // Unsuccessfully try to claim fraud again
-  expect(
+  await expect(
     customer2L2.refundOnFraud(
       0,
       1,
@@ -178,13 +180,15 @@ it("Able to prove fraud", async () => {
   };
   const fraudSignature2 = signData(hashTickets(ticketsWithIndex2), lpPK);
 
-  await customer2L2.refundOnFraud(
-    2,
-    0,
-    1,
-    1,
-    [ticket3, fraudTicket2],
-    fraudSignature2,
-    { gasLimit },
+  await waitForTx(
+    customer2L2.refundOnFraud(
+      2,
+      0,
+      1,
+      1,
+      [ticket3, fraudTicket2],
+      fraudSignature2,
+      { gasLimit },
+    ),
   );
 });

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -117,14 +117,16 @@ it("Unable to authorize overlapping batches", async () => {
 
 it("Able to prove fraud", async () => {
   /**
-   * Fraud committed before a batch is authorized. The liquidity provider signs a batch
-   *  of tickets with the second ticket's l1Recipient switched to LP's address
+   * Fraud instance 1. The liquidity provider signs a batch of tickets with the
+   * second ticket's l1Recipient switched to LP's address
    */
   await deposit(0, 10);
 
   // Sign fraudulent batch
   const ticket = await lpL2.tickets(0);
   const ticket2 = await lpL2.tickets(1);
+  await authorizeWithdrawal(0);
+
   const fraudTicket = { ...ticket2, l1Recipient: lpWallet.address };
   const ticketsWithIndex: TicketsWithIndex = {
     startIndex: 0,
@@ -158,7 +160,7 @@ it("Able to prove fraud", async () => {
   ).to.be.rejectedWith("Batch status must be Authorized");
 
   /**
-   * Fraud committed after a batch is authorized. The setup is:
+   * Fraud instance 2. The setup is:
    * - There are 4 tickets. The first two tickets have been refunded above.
    * - The second two tickets are authorized by LP.
    * - LP signs a batch that includes a correct 2nd ticket and a fraudulent 3rd ticket.


### PR DESCRIPTION
Fixes https://github.com/statechannels/SAFE-protocol/issues/59.

There are 2 cases of fraud:
1. A ticket `t` is created on deposit. The ticket **is authorized as part of a batch**. The liquidity provider (LP) also signs another batch that contains a ticket with the same index as `t` but different data.
~~2. Same as above but `t` is never authorized.~~

~~In the second case, a new batch is created on fraud proof. The batch includes all tickets from the last authorized ticket (exclusive) to the ticket that is being "cheated" (inclusive).~~

On more thought, it doesn't seem like we need to take care of the second case. The customer can:
- prove fraud if the ticket is authorized before the auth window expires.
- get their funds back after the auth window expires if the ticket is never authorized.
