### PR TITLE
Add refunds

### DIFF
--- a/contracts/common.sol
+++ b/contracts/common.sol
@@ -11,7 +11,7 @@ struct Ticket {
     /// The amount of funds to send.
     uint256 value;
     /// The timestamp when the ticket was registered
-    uint256 timestamp;
+    uint256 createdAt;
 }
 
 struct TicketsWithIndex {

--- a/contracts/l2.sol
+++ b/contracts/l2.sol
@@ -35,7 +35,7 @@ uint256 constant safetyDelay = 60;
 
 contract L2 is SignatureChecker {
     Ticket[] public tickets;
-    // `batches` is used to record the fact that tickets with nonce between startingNonce and startingNonce + numTickets-1 are authorized, claimed or refunded.
+    // `batches` is used to record the fact that tickets with nonce between startingNonce and startingNonce + numTickets-1 are authorized or withdrawn.
     // Indexed by nonce
     mapping(uint256 => Batch) batches;
     uint256 nextBatchStart = 0;

--- a/contracts/l2.sol
+++ b/contracts/l2.sol
@@ -62,7 +62,7 @@ contract L2 is SignatureChecker {
         Ticket memory ticket = Ticket({
             l1Recipient: deposit.l1Recipient,
             value: deposit.depositAmount,
-            timestamp: block.timestamp
+            createdAt: block.timestamp
         });
 
         // ticket's nonce is now its index in `tickets`
@@ -79,7 +79,7 @@ contract L2 is SignatureChecker {
             TicketsWithIndex memory ticketsWithIndex
         ) = createBatch(first, last);
         bytes32 message = keccak256(abi.encode(ticketsWithIndex));
-        uint256 earliestTimestamp = tickets[first].timestamp;
+        uint256 earliestTimestamp = tickets[first].createdAt;
 
         require(nextBatchStart == first, "Batches must be gapless");
         require(
@@ -194,7 +194,7 @@ contract L2 is SignatureChecker {
      */
     function refund(uint256 lastNonce) public {
         require(
-            block.timestamp > tickets[lastNonce].timestamp + maxAuthDelay,
+            block.timestamp > tickets[lastNonce].createdAt + maxAuthDelay,
             "maxAuthDelay must have passed since deposit"
         );
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const SIGNED_SWAPS_ABI_TYPE = [
-  "tuple(uint256 startIndex, tuple(address l1Recipient, uint256 value, uint256 timestamp)[]) ",
+  "tuple(uint256 startIndex, tuple(address l1Recipient, uint256 value, uint256 createdAt)[]) ",
 ];
 
 export const USE_ERC20 = process.env.USE_ERC20 === "true";

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -192,3 +192,21 @@ it("Handles a fraud proofs", async () => {
     ),
   );
 });
+
+it("Able to get a ticket refunded", async () => {
+  await deposit(0, 10);
+  await expect(customerL2.refund(0, { gasLimit })).to.be.rejectedWith(
+    "maxAuthDelay must have passed since deposit",
+  );
+  await ethers.provider.send("evm_increaseTime", [61]);
+  await waitForTx(customerL2.refund(0, { gasLimit }));
+  await waitForTx(customerL2.refund(1, { gasLimit }));
+  await expect(customerL2.refund(1, { gasLimit })).to.be.rejectedWith(
+    "The nonce must not be a part of a batch",
+  );
+
+  await deposit(2, 8);
+  await ethers.provider.send("evm_increaseTime", [61]);
+  // Refund 3rd and 4th deposit
+  await waitForTx(customerL2.refund(2, { gasLimit }));
+});


### PR DESCRIPTION
A customer can refund a ticket after the authorization window expires. When refund is called for a ticket:
1. A batch is created with all tickets between the last authorized ticket (exclusive) and the ticket being refunded (inclusive).
2. All tickets in the batch are refunded.

This PR also reduces `BatchStatus` to 2 types: Authorized and Withdrawn.

Fixes https://github.com/statechannels/SAFE-protocol/issues/74