### PR TITLE
add warning to yarn 3 installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ This is a prototype of the SAFE protocol. The protocol allows for secure, trustl
 The protocol is described in detail in the [SAFE paper](https://www.notion.so/statechannels/SAFE-Protocol-cf0b29e8656d4c3e8edfe8329b2fa67e).
 
 # Getting started
-This project uses yarn version 3. You can install yarn version 3 by following [these instructions](https://yarnpkg.com/getting-started/install) from the parent folder of this repository. This will cause all child folders of the parent directory to use yarn version 3.
+This project uses yarn version 3. You can install yarn version 3 by following [these instructions](https://yarnpkg.com/getting-started/install) from the parent folder of this repository. :warning:This will cause all child folders of the parent directory to use yarn version 3.:warning:
 
 ## Commands
 - `yarn` to install dependencies.


### PR DESCRIPTION
The instructions are not very polite towards developers. We should
clearly point out that the installation instructions can trigger
widespread changes to a developer's system.