### PR TITLE
Simplify tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,4 @@ jobs:
         with:
           node-version: "16"
       - run: yarn
-      - run: yarn test:token
-      - run: yarn test:eth
+      - run: yarn test

--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
     "typechain": "^6.0.3"
   },
   "scripts": {
-    "test": "yarn test:eth && yarn test:token",
-    "test:eth": "yarn hardhat test",
-    "test:token": "USE_ERC20=true yarn hardhat test",
+    "test": "yarn hardhat test",
     "typechain": "yarn hardhat typechain",
     "postinstall": "yarn typechain"
   }


### PR DESCRIPTION
In preparation for working on https://github.com/statechannels/SAFE-protocol/issues/51, I am simplifying the tests with the following changes:
- references to `ERC20` tokens testing are removed. (currently we run the same tests twice)
- the 2nd customer wallet is removed -- the first customer submits all tickets.