### PR TITLE
perf: don't include createdAt in L1 calldata

### DIFF
--- a/contracts/common.sol
+++ b/contracts/common.sol
@@ -5,6 +5,13 @@ address constant lpAddress = address(
     0x9552ceB4e6FA8c356c1A76A8Bc8b1EFA7B9fb205
 );
 
+struct L1Ticket {
+    /// Who will get the funds if executed
+    address l1Recipient;
+    /// The amount of funds to send.
+    uint256 value;
+}
+
 struct Ticket {
     /// Who will get the funds if executed
     address l1Recipient;
@@ -16,7 +23,7 @@ struct Ticket {
 
 struct TicketsWithNonce {
     uint256 startNonce;
-    Ticket[] tickets;
+    L1Ticket[] tickets;
 }
 
 struct Signature {
@@ -35,5 +42,9 @@ abstract contract SignatureChecker {
             abi.encodePacked("\x19Ethereum Signed Message:\n32", hash)
         );
         return ecrecover(prefixedHash, signature.v, signature.r, signature.s);
+    }
+
+    function ticketsEqual(L1Ticket memory t1, L1Ticket memory t2) public pure returns (bool) {
+        return (t1.value == t2.value) && (t1.l1Recipient == t2.l1Recipient);
     }
 }

--- a/contracts/l1.sol
+++ b/contracts/l1.sol
@@ -8,7 +8,7 @@ contract l1 is SignatureChecker {
 
     receive() external payable {}
 
-    function claimBatch(Ticket[] calldata tickets, Signature calldata signature)
+    function claimBatch(L1Ticket[] calldata tickets, Signature calldata signature)
         public
     {
         bytes32 message = keccak256(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const SIGNED_SWAPS_ABI_TYPE = [
-  "tuple(uint256 startNonce, tuple(address l1Recipient, uint256 value, uint256 createdAt)[]) ",
+  "tuple(uint256 startNonce, tuple(address l1Recipient, uint256 value)[]) ",
 ];
 
 export const USE_ERC20 = process.env.USE_ERC20 === "true";

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -74,7 +74,7 @@ async function authorizeWithdrawal(
   trustedNonce: number,
   numTickets = 2
 ): Promise<{ tickets: L1TicketStruct[]; signature: ethersTypes.Signature }> {
-  let tickets: L1TicketStruct[] = [];
+  const tickets: L1TicketStruct[] = [];
   for (let i = 0; i < numTickets; i++) {
     tickets.push(ticketToL1Ticket(await lpL2.tickets(trustedNonce + i)));
   }


### PR DESCRIPTION
**MARKED AS DRAFT** since this is not important work. (I wanted to see how big an impact the unnecessary data made on the asymptotic cost.)

The createdAt timestamp isn't used in L1. Including it in the data that is provided to the L1 contract (and also including it in the data that is hashed and signed by the liquidity provider) is wasteful.

This adds an L1Ticket struct which includes only the required data, which is the recipient and value of the transfer.

This reduces the batch size required to get under 9k/swap from 86 to 61, and reduces the asymptotic cost from ~8700/ticket to ~8600/ticket.

# BEFORE
<img width="453" alt="Screen Shot 2021-12-16 at 2 19 57 PM" src="https://user-images.githubusercontent.com/8432675/146457506-c3837289-615d-47a7-851f-19092f2d30e9.png">

# AFTER

<img width="456" alt="Screen Shot 2021-12-16 at 2 37 48 PM" src="https://user-images.githubusercontent.com/8432675/146459369-6ad250ee-929f-4dc0-baa6-65aa6128c07f.png">

