### PR TITLE
Switch prototype to transfer ERC20

### DIFF
--- a/contracts/common.sol
+++ b/contracts/common.sol
@@ -12,6 +12,8 @@ struct L1Ticket {
     address l1Recipient;
     /// The amount of funds to send.
     uint256 value;
+    /// The address of the ERC20 token to use. If set to 0, then ETH is used.
+    address token;
 }
 
 struct Ticket {
@@ -48,7 +50,11 @@ abstract contract SignatureChecker {
         return ecrecover(prefixedHash, signature.v, signature.r, signature.s);
     }
 
-    function ticketsEqual(L1Ticket memory t1, L1Ticket memory t2) public pure returns (bool) {
+    function ticketsEqual(L1Ticket memory t1, L1Ticket memory t2)
+        public
+        pure
+        returns (bool)
+    {
         return (t1.value == t2.value) && (t1.l1Recipient == t2.l1Recipient);
     }
 }

--- a/contracts/common.sol
+++ b/contracts/common.sol
@@ -12,7 +12,7 @@ struct L1Ticket {
     address l1Recipient;
     /// The amount of funds to send.
     uint256 value;
-    /// The address of the ERC20 token to use. If set to 0, then ETH is used.
+    /// The address of the ERC20 token to use.
     address token;
 }
 

--- a/contracts/common.sol
+++ b/contracts/common.sol
@@ -23,7 +23,7 @@ struct Ticket {
     uint256 value;
     /// The timestamp when the ticket was registered
     uint256 createdAt;
-    /// The address of the ERC20 token to use. If set to 0, then ETH is used.
+    /// The address of the ERC20 token to use.
     address token;
 }
 
@@ -56,22 +56,5 @@ abstract contract SignatureChecker {
         returns (bool)
     {
         return (t1.value == t2.value) && (t1.l1Recipient == t2.l1Recipient);
-    }
-}
-
-abstract contract FundsSender {
-    function sendFunds(
-        address receiver,
-        uint256 value,
-        address tokenAddress
-    ) public {
-        if (tokenAddress == address(0)) {
-            // This is based on https://solidity-by-example.org/sending-ether/
-            (bool sent, ) = receiver.call{value: value}("");
-            require(sent, "Failed to send Ether");
-        } else {
-            IERC20 tokenContract = IERC20(tokenAddress);
-            tokenContract.transfer(receiver, value);
-        }
     }
 }

--- a/contracts/common.sol
+++ b/contracts/common.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.10;
 
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
 address constant lpAddress = address(
     0x9552ceB4e6FA8c356c1A76A8Bc8b1EFA7B9fb205
 );
@@ -19,6 +21,8 @@ struct Ticket {
     uint256 value;
     /// The timestamp when the ticket was registered
     uint256 createdAt;
+    /// The address of the ERC20 token to use. If set to 0, then ETH is used.
+    address token;
 }
 
 struct TicketsWithNonce {
@@ -46,5 +50,22 @@ abstract contract SignatureChecker {
 
     function ticketsEqual(L1Ticket memory t1, L1Ticket memory t2) public pure returns (bool) {
         return (t1.value == t2.value) && (t1.l1Recipient == t2.l1Recipient);
+    }
+}
+
+abstract contract FundsSender {
+    // This is based on https://solidity-by-example.org/sending-ether/
+    function send(
+        address receiver,
+        uint256 value,
+        address tokenAddress
+    ) public {
+        if (tokenAddress == address(0)) {
+            (bool sent, ) = receiver.call{value: value}("");
+            require(sent, "Failed to send Ether");
+        } else {
+            IERC20 tokenContract = IERC20(tokenAddress);
+            tokenContract.transfer(receiver, value);
+        }
     }
 }

--- a/contracts/common.sol
+++ b/contracts/common.sol
@@ -60,13 +60,13 @@ abstract contract SignatureChecker {
 }
 
 abstract contract FundsSender {
-    // This is based on https://solidity-by-example.org/sending-ether/
-    function send(
+    function sendFunds(
         address receiver,
         uint256 value,
         address tokenAddress
     ) public {
         if (tokenAddress == address(0)) {
+            // This is based on https://solidity-by-example.org/sending-ether/
             (bool sent, ) = receiver.call{value: value}("");
             require(sent, "Failed to send Ether");
         } else {

--- a/contracts/l1.sol
+++ b/contracts/l1.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.10;
 
 import "./common.sol";
 
-contract l1 is SignatureChecker {
+contract l1 is SignatureChecker, FundsSender {
     uint256 nextNonce = 0;
 
     receive() external payable {}
@@ -21,10 +21,7 @@ contract l1 is SignatureChecker {
         );
 
         for (uint256 i = 0; i < tickets.length; i++) {
-            (bool sent, ) = tickets[i].l1Recipient.call{
-                value: tickets[i].value
-            }("");
-            require(sent, "Failed to send Ether");
+            send(tickets[i].l1Recipient, tickets[i].value, tickets[i].token);
         }
 
         nextNonce = nextNonce + tickets.length;

--- a/contracts/l1.sol
+++ b/contracts/l1.sol
@@ -21,7 +21,11 @@ contract l1 is SignatureChecker, FundsSender {
         );
 
         for (uint256 i = 0; i < tickets.length; i++) {
-            send(tickets[i].l1Recipient, tickets[i].value, tickets[i].token);
+            sendFunds(
+                tickets[i].l1Recipient,
+                tickets[i].value,
+                tickets[i].token
+            );
         }
 
         nextNonce = nextNonce + tickets.length;

--- a/contracts/l1.sol
+++ b/contracts/l1.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.10;
 
 import "./common.sol";
 
-contract l1 is SignatureChecker, FundsSender {
+contract l1 is SignatureChecker {
     uint256 nextNonce = 0;
 
     receive() external payable {}
@@ -21,11 +21,8 @@ contract l1 is SignatureChecker, FundsSender {
         );
 
         for (uint256 i = 0; i < tickets.length; i++) {
-            sendFunds(
-                tickets[i].l1Recipient,
-                tickets[i].value,
-                tickets[i].token
-            );
+            IERC20 tokenContract = IERC20(tickets[i].token);
+            tokenContract.transfer(tickets[i].l1Recipient, tickets[i].value);
         }
 
         nextNonce = nextNonce + tickets.length;

--- a/contracts/l2.sol
+++ b/contracts/l2.sol
@@ -85,7 +85,11 @@ contract L2 is SignatureChecker, FundsSender {
 
     // TODO: This public function is added to force hardhat to generate
     // the TicketStruct type in its l2.ts output
-    function compareWithFirstTicket(Ticket calldata t) public view returns (bool) {
+    function compareWithFirstTicket(Ticket calldata t)
+        public
+        view
+        returns (bool)
+    {
         return tickets[0].value == t.value;
     }
 
@@ -125,7 +129,11 @@ contract L2 is SignatureChecker, FundsSender {
         uint256 total = 0;
         for (uint256 i = first; i <= last; i++) {
             Ticket memory t = tickets[i];
-            ticketsToAuthorize[i - first] = L1Ticket(t.l1Recipient, t.value);
+            ticketsToAuthorize[i - first] = L1Ticket(
+                t.l1Recipient,
+                t.value,
+                t.token
+            );
             total += tickets[i].value;
         }
         return (
@@ -189,7 +197,11 @@ contract L2 is SignatureChecker, FundsSender {
         );
 
         Ticket memory t = tickets[honestStartNonce + honestDelta];
-        L1Ticket memory correctTicket = L1Ticket(t.l1Recipient, t.value);
+        L1Ticket memory correctTicket = L1Ticket(
+            t.l1Recipient,
+            t.value,
+            t.token
+        );
         L1Ticket memory fraudTicket = fraudTickets[fraudDelta];
         require(
             !ticketsEqual(correctTicket, fraudTicket),
@@ -234,5 +246,4 @@ contract L2 is SignatureChecker, FundsSender {
             tickets[lastNonce].token
         );
     }
-
 }

--- a/contracts/l2.sol
+++ b/contracts/l2.sol
@@ -76,7 +76,7 @@ contract L2 is SignatureChecker, FundsSender {
             l1Recipient: deposit.l1Recipient,
             value: deposit.depositAmount,
             createdAt: block.timestamp,
-            token: address(0)
+            token: deposit.token
         });
 
         // ticket's nonce is now its index in `tickets`

--- a/contracts/l2.sol
+++ b/contracts/l2.sol
@@ -163,7 +163,7 @@ contract L2 is SignatureChecker, FundsSender {
 
         for (uint256 i = first; i < first + batch.numTickets; i++) {
             Ticket memory ticket = tickets[i];
-            send(lpAddress, ticket.value, ticket.token);
+            sendFunds(lpAddress, ticket.value, ticket.token);
         }
     }
 
@@ -215,7 +215,11 @@ contract L2 is SignatureChecker, FundsSender {
         );
 
         for (uint256 i = honestStartNonce; i < honestBatch.numTickets; i++) {
-            send(tickets[i].l1Recipient, tickets[i].value, tickets[i].token);
+            sendFunds(
+                tickets[i].l1Recipient,
+                tickets[i].value,
+                tickets[i].token
+            );
         }
 
         batches[honestStartNonce].status = BatchStatus.Withdrawn;
@@ -240,7 +244,7 @@ contract L2 is SignatureChecker, FundsSender {
         batch.status = BatchStatus.Withdrawn;
         nextBatchStart = lastNonce + 1;
 
-        send(
+        sendFunds(
             tickets[lastNonce].l1Recipient,
             tickets[lastNonce].value,
             tickets[lastNonce].token

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const SIGNED_SWAPS_ABI_TYPE = [
-  "tuple(uint256 startNonce, tuple(address l1Recipient, uint256 value)[]) ",
+  "tuple(uint256 startNonce, tuple(address l1Recipient, uint256 value, address token)[]) ",
 ];
 
 export const USE_ERC20 = process.env.USE_ERC20 === "true";

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -356,8 +356,6 @@ it("gas benchmarking", async () => {
   const benchmarkScenarios = [
     1,
     2,
-    5,
-    20,
     50,
     62, // THE GAS COST IS ... UNDER 9000!!!
   ];

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -366,7 +366,7 @@ it("gas benchmarking", async () => {
   ethResults = ethRun.results;
   const erc20run = await benchmark(benchmarkScenarios, ethRun.nonce, false);
   erc20Results = erc20run.results;
-});
+}).timeout(60_000); // TODO: We should probably split gas benchmarking into it's own test command so unit tests can run faster
 
 // Currently using numbers for convenience, as the amount of tokens is pretty small
 type TokenBalances = {

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -9,7 +9,12 @@ import { L1__factory } from "../contract-types/factories/L1__factory";
 import { L2__factory } from "../contract-types/factories/L2__factory";
 import { L1, L1TicketStruct } from "../contract-types/L1";
 import { L2, L2DepositStruct, TicketStruct } from "../contract-types/L2";
-import { MAX_AUTH_DELAY, SAFETY_DELAY } from "../src/constants";
+
+import {
+  ETH_TOKEN_ADDRESS,
+  MAX_AUTH_DELAY,
+  SAFETY_DELAY,
+} from "../src/constants";
 import { TicketsWithNonce } from "../src/types";
 import { hashTickets, signData } from "../src/utils";
 import { printScenarioGasUsage, ScenarioGasUsage } from "./utils";
@@ -48,6 +53,7 @@ async function deposit(trustedNonce: number, trustedAmount: number) {
     trustedAmount,
     depositAmount,
     l1Recipient: customerWallet.address,
+    token: ETH_TOKEN_ADDRESS,
   };
   const deposit2: L2DepositStruct = {
     ...deposit,
@@ -65,11 +71,11 @@ async function depositOnce(trustedNonce: number, trustedAmount: number) {
     trustedAmount,
     depositAmount,
     l1Recipient: customerWallet.address,
+    token: ETH_TOKEN_ADDRESS,
   };
 
   await waitForTx(customerL2.depositOnL2(deposit, { value: depositAmount }));
 }
-
 async function authorizeWithdrawal(
   trustedNonce: number,
   numTickets = 2

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -249,7 +249,7 @@ it("Handles a fraud proofs", async () => {
       1,
       0,
       1,
-      [ticket, fraudTicket],
+      [ticket, fraudTicket].map(ticketToL1Ticket),
       fraudSignature,
       { gasLimit }
     )
@@ -262,7 +262,7 @@ it("Handles a fraud proofs", async () => {
       1,
       0,
       1,
-      [ticket, fraudTicket],
+      [ticket, fraudTicket].map(ticketToL1Ticket),
       fraudSignature,
       {
         gasLimit,
@@ -295,7 +295,7 @@ it("Handles a fraud proofs", async () => {
       0,
       1,
       1,
-      [ticket3, fraudTicket2],
+      [ticket3, fraudTicket2].map(ticketToL1Ticket),
       fraudSignature2,
       { gasLimit }
     )

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -23,7 +23,7 @@ import { hashTickets, signData } from "../src/utils";
 import { printScenarioGasUsage, ScenarioGasUsage } from "./utils";
 
 const gasLimit = 30_000_000;
-const tokenBalance = 10_000_000;
+const tokenBalance = 1_000_000;
 // Address 0x2a47Cd5718D67Dc81eAfB24C99d4db159B0e7bCa
 const customerPK =
   "0xe1743f0184b85ac1412311be9d6e5d333df23e22efdf615d0135ca2b9ed67938";
@@ -152,8 +152,10 @@ beforeEach(async () => {
   const l1 = await l1Deployer.deploy();
   const l2 = await l2Deployer.deploy();
   testToken = await tokenDeployer.deploy(tokenBalance);
-  // Transfer half of the tokens to the customer account so both have funds to play with
-  await testToken.transfer(customerWallet.address, tokenBalance / 2);
+  // Transfer 1/4 to the customer account
+  await testToken.transfer(customerWallet.address, tokenBalance / 4);
+  // Transfer 1/4 to the l1 contract for payouts
+  await testToken.transfer(l1.address, tokenBalance / 4);
   // Approve both contracts for both parties to transfer tokens
   await testToken.approve(l2.address, tokenBalance);
   await testToken.approve(l1.address, tokenBalance);

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -360,9 +360,9 @@ it("gas benchmarking", async () => {
     62, // THE GAS COST IS ... UNDER 9000!!!
   ];
 
-  const ethRun = await benchmark(benchmarkScenarios, nonce, true);
+  const ethRun = await benchmark(benchmarkScenarios, nonce, false);
   ethResults = ethRun.results;
-  const erc20run = await benchmark(benchmarkScenarios, ethRun.nonce, false);
+  const erc20run = await benchmark(benchmarkScenarios, ethRun.nonce, true);
   erc20Results = erc20run.results;
 }).timeout(60_000); // TODO: We should probably split gas benchmarking into it's own test command so unit tests can run faster
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -6,11 +6,8 @@ export type ScenarioGasUsage = {
   totalGasUsed: BigNumber;
 };
 
-export function printScenarioGasUsage(
-  scenarios: ScenarioGasUsage[],
-  description = "L1 claimBatch Gas Usage"
-) {
-  console.log(description);
+export function printScenarioGasUsage(scenarios: ScenarioGasUsage[]) {
+  console.log("L1 claimBatch Gas Usage");
   const table = new Table({
     head: ["Ticket Batch Size", "Average Gas Per Ticket", "Total Gas Used"],
     colAligns: ["right", "right", "right"],

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -6,8 +6,11 @@ export type ScenarioGasUsage = {
   totalGasUsed: BigNumber;
 };
 
-export function printScenarioGasUsage(scenarios: ScenarioGasUsage[]) {
-  console.log("L1 claimBatch Gas Usage");
+export function printScenarioGasUsage(
+  scenarios: ScenarioGasUsage[],
+  description = "L1 claimBatch Gas Usage"
+) {
+  console.log(description);
   const table = new Table({
     head: ["Ticket Batch Size", "Average Gas Per Ticket", "Total Gas Used"],
     colAligns: ["right", "right", "right"],


### PR DESCRIPTION
This PR switches the prototype to transfer ERC20 tokens **instead** of ETH.

Fixes #93 

There is further work to do for more accurate benchmarking that will be tackled in #94.