### PR TITLE
More realistic testing

### DIFF
--- a/test/benchmarking.test.ts
+++ b/test/benchmarking.test.ts
@@ -18,22 +18,6 @@ import {
   waitForTx,
 } from "./utils";
 
-/**
- * Generates a random pk/address and then sends a small amount of ETH to the address
- * This ensures that the address is present in the state trie when we go to call claimBatch avoiding additional gas fees.
- * In a real life scenario it is a reasonable assumption to assume the account already exists in the state trie.
- */
-async function createCustomer(): Promise<string> {
-  const lpWallet = new ethers.Wallet(lpPK, ethers.provider);
-  const { address } = Wallet.createRandom({}).connect(ethers.provider);
-
-  // Send a small amount of ETH to the address to ensure it is present in the state trie.
-  await lpWallet.sendTransaction({
-    to: address,
-    value: ethers.utils.parseUnits("1", "wei"),
-  });
-  return address;
-}
 async function generateTickets(
   startNonce = 0,
   numTickets = 2,
@@ -43,14 +27,14 @@ async function generateTickets(
   const tickets: TicketStruct[] = [];
   const customers: string[] = [];
   for (let i = 0; i < numCustomers; i++) {
-    customers.push(await createCustomer());
+    customers.push(Wallet.createRandom({}).address);
   }
 
   for (let i = 0; i < numTickets; i++) {
     let customer: string;
     // Generate a new untouched address for
     if (numCustomers === "Unique") {
-      customer = await createCustomer();
+      customer = Wallet.createRandom({}).address;
     } else {
       customer = customers[Math.floor(Math.random() * customers.length)];
     }

--- a/test/benchmarking.test.ts
+++ b/test/benchmarking.test.ts
@@ -37,7 +37,6 @@ async function generateTickets(
 
   let customer = await createCustomer();
   for (let i = 0; i < numTickets; i++) {
-    // Generate a new untouched address for
     if (customerMode === "Unique") {
       customer = await createCustomer();
     }

--- a/test/benchmarking.test.ts
+++ b/test/benchmarking.test.ts
@@ -75,7 +75,7 @@ beforeEach(async () => {
   // Transfer 1/4 to the l1 contract for payouts
   await testToken.transfer(l1Contract.address, tokenBalance / 4);
 
-  await testToken.approve(l1Contract.address, tokenBalance);
+  //   await testToken.approve(l1Contract.address, tokenBalance);
 });
 
 const benchmarkResults: ScenarioGasUsage[] = [];

--- a/test/benchmarking.test.ts
+++ b/test/benchmarking.test.ts
@@ -8,7 +8,7 @@ import { ethers } from "hardhat";
 import { L1__factory } from "../contract-types/factories/L1__factory";
 import { TestToken__factory } from "../contract-types/factories/TestToken__factory";
 import { TestToken } from "../contract-types/TestToken";
-import { L1, TicketStruct } from "../contract-types/L1";
+import { L1, L1TicketStruct } from "../contract-types/L1";
 import { TicketsWithNonce } from "../src/types";
 import { hashTickets, signData } from "../src/utils";
 import {
@@ -32,8 +32,8 @@ async function generateTickets(
   numTickets = 2,
   customerMode: "Unique" | "Same" = "Unique",
   amountOfTokens = 1
-): Promise<{ tickets: TicketStruct[]; signature: ethersTypes.Signature }> {
-  const tickets: TicketStruct[] = [];
+): Promise<{ tickets: L1TicketStruct[]; signature: ethersTypes.Signature }> {
+  const tickets: L1TicketStruct[] = [];
 
   let customer = await createCustomer();
   for (let i = 0; i < numTickets; i++) {
@@ -44,7 +44,6 @@ async function generateTickets(
       l1Recipient: customer,
       value: amountOfTokens,
       token: testToken.address,
-      createdAt: Math.round(Date.now() / 1000),
     });
   }
   const ticketsWithNonce: TicketsWithNonce = {

--- a/test/benchmarking.test.ts
+++ b/test/benchmarking.test.ts
@@ -18,6 +18,16 @@ import {
   waitForTx,
 } from "./utils";
 
+async function createCustomer(): Promise<string> {
+  const { address } = Wallet.createRandom({}).connect(ethers.provider);
+  // We assume that the customer has interacted with the token contract before
+  // To simulate this we transfer a small amount, triggering the write to zero storage.
+  // This prevents the gas cost of claimBatch including a write to zero storage.
+  // TODO: Is it realistic to just do this for all customers?
+  await testToken.transfer(address, 1);
+
+  return address;
+}
 async function generateTickets(
   startNonce = 0,
   numTickets = 2,
@@ -27,14 +37,14 @@ async function generateTickets(
   const tickets: TicketStruct[] = [];
   const customers: string[] = [];
   for (let i = 0; i < numCustomers; i++) {
-    customers.push(Wallet.createRandom({}).address);
+    customers.push(await createCustomer());
   }
 
   for (let i = 0; i < numTickets; i++) {
     let customer: string;
     // Generate a new untouched address for
     if (numCustomers === "Unique") {
-      customer = Wallet.createRandom({}).address;
+      customer = await createCustomer();
     } else {
       customer = customers[Math.floor(Math.random() * customers.length)];
     }

--- a/test/benchmarking.test.ts
+++ b/test/benchmarking.test.ts
@@ -20,10 +20,9 @@ import {
 
 async function createCustomer(): Promise<string> {
   const { address } = Wallet.createRandom({}).connect(ethers.provider);
-  // We assume that the customer has interacted with the token contract before
-  // To simulate this we transfer a small amount, triggering the write to zero storage.
-  // This prevents the gas cost of claimBatch including a write to zero storage.
-  // TODO: Is it realistic to just do this for all customers?
+  // We assume the customer currently holds, or has previously held, some of the ERC20 tokens on L1.
+  // To simulate this we transfer a small amount of tokens to the customer's address, triggering the initial storage write.
+  // This prevents the gas cost of claimBatch including a write to zero storage cost for the first time the customer receives tokens.
   await testToken.transfer(address, 1);
 
   return address;

--- a/test/benchmarking.test.ts
+++ b/test/benchmarking.test.ts
@@ -1,0 +1,131 @@
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+chai.use(chaiAsPromised);
+
+import { ethers as ethersTypes, Wallet } from "ethers";
+import { ethers } from "hardhat";
+
+import { L1__factory } from "../contract-types/factories/L1__factory";
+import { TestToken__factory } from "../contract-types/factories/TestToken__factory";
+import { TestToken } from "../contract-types/TestToken";
+import { L1, TicketStruct } from "../contract-types/L1";
+import { TicketsWithNonce } from "../src/types";
+import { hashTickets, signData } from "../src/utils";
+import {
+  lpPK,
+  printScenarioGasUsage,
+  ScenarioGasUsage,
+  waitForTx,
+} from "./utils";
+
+/**
+ * Generates a random pk/address and then sends a small amount of ETH to the address
+ * This ensures that the address is present in the state trie when we go to call claimBatch avoiding additional gas fees.
+ * In a real life scenario it is a reasonable assumption to assume the account already exists in the state trie.
+ */
+async function createCustomer(): Promise<string> {
+  const lpWallet = new ethers.Wallet(lpPK, ethers.provider);
+  const { address } = Wallet.createRandom({}).connect(ethers.provider);
+
+  // Send a small amount of ETH to the address to ensure it is present in the state trie.
+  await lpWallet.sendTransaction({
+    to: address,
+    value: ethers.utils.parseUnits("1", "wei"),
+  });
+  return address;
+}
+async function generateTickets(
+  startNonce = 0,
+  numTickets = 2,
+  numCustomers: number | "Unique" = 1,
+  amountOfTokens = 1
+): Promise<{ tickets: TicketStruct[]; signature: ethersTypes.Signature }> {
+  const tickets: TicketStruct[] = [];
+  const customers: string[] = [];
+  for (let i = 0; i < numCustomers; i++) {
+    customers.push(await createCustomer());
+  }
+
+  for (let i = 0; i < numTickets; i++) {
+    let customer: string;
+    // Generate a new untouched address for
+    if (numCustomers === "Unique") {
+      customer = await createCustomer();
+    } else {
+      customer = customers[Math.floor(Math.random() * customers.length)];
+    }
+    tickets.push({
+      l1Recipient: customer,
+      value: amountOfTokens,
+      token: testToken.address,
+      createdAt: Math.round(Date.now() / 1000),
+    });
+  }
+  const ticketsWithNonce: TicketsWithNonce = {
+    startNonce,
+    tickets,
+  };
+
+  const signature = signData(hashTickets(ticketsWithNonce), lpPK);
+
+  return { tickets, signature };
+}
+
+let l1Contract: L1;
+
+let testToken: TestToken;
+
+beforeEach(async () => {
+  const lpWallet = new ethers.Wallet(lpPK, ethers.provider);
+
+  const l1Deployer = new L1__factory(lpWallet);
+
+  const tokenDeployer = new TestToken__factory(lpWallet);
+  l1Contract = await l1Deployer.deploy();
+
+  const tokenBalance = 1_000_000;
+
+  testToken = await tokenDeployer.deploy(tokenBalance);
+
+  // Transfer 1/4 to the l1 contract for payouts
+  await testToken.transfer(l1Contract.address, tokenBalance / 4);
+
+  await testToken.approve(l1Contract.address, tokenBalance);
+});
+
+const benchmarkResults: ScenarioGasUsage[] = [];
+it.only("gas benchmarking", async () => {
+  let nonce = 0;
+  const initial = await generateTickets(0, 1, 1, 1);
+  // The FIRST batch that is claimed on L1 incurs a write-to-zero-storage cost, which makes
+  // for a counter-intuitive list of results. So, we trigger an initial swap before
+  // starting the benchmark
+
+  await waitForTx(l1Contract.claimBatch(initial.tickets, initial.signature));
+
+  nonce++;
+
+  const benchmarkScenarios = [
+    1,
+    2,
+    5,
+    20,
+    50,
+    86, // THE GAS COST IS ... UNDER 9000!!!
+  ];
+
+  for (const batchSize of benchmarkScenarios) {
+    const { tickets, signature } = await generateTickets(
+      nonce,
+      batchSize,
+      "Unique"
+    );
+    const { gasUsed } = await waitForTx(
+      l1Contract.claimBatch(tickets, signature)
+    );
+    benchmarkResults.push({ totalGasUsed: gasUsed, batchSize });
+    nonce += batchSize;
+  }
+});
+
+after(() => printScenarioGasUsage(benchmarkResults));

--- a/test/benchmarking.test.ts
+++ b/test/benchmarking.test.ts
@@ -27,6 +27,22 @@ async function createCustomer(): Promise<string> {
 
   return address;
 }
+async function runScenario(
+  nonce: number,
+  batchSize: number,
+  customerMode: "Unique" | "Same"
+): Promise<ScenarioGasUsage> {
+  const { tickets, signature } = await generateTickets(
+    nonce,
+    batchSize,
+    customerMode
+  );
+  const { gasUsed } = await waitForTx(
+    l1Contract.claimBatch(tickets, signature)
+  );
+  return { totalGasUsed: gasUsed, batchSize };
+}
+
 async function generateTickets(
   startNonce = 0,
   numTickets = 2,
@@ -103,21 +119,5 @@ it("gas benchmarking", async () => {
     nonce += batchSize;
   }
 });
-
-async function runScenario(
-  nonce: number,
-  batchSize: number,
-  customerMode: "Unique" | "Same"
-): Promise<ScenarioGasUsage> {
-  const { tickets, signature } = await generateTickets(
-    nonce,
-    batchSize,
-    customerMode
-  );
-  const { gasUsed } = await waitForTx(
-    l1Contract.claimBatch(tickets, signature)
-  );
-  return { totalGasUsed: gasUsed, batchSize };
-}
 
 after(() => printScenarioGasUsage(benchmarkResults));

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -5,19 +5,31 @@ import { ethers as ethersTypes } from "ethers";
 export type ScenarioGasUsage = {
   batchSize: number;
   totalGasUsed: BigNumber;
+  customer: "Unique" | "Same";
 };
 
 export function printScenarioGasUsage(scenarios: ScenarioGasUsage[]) {
   console.log("L1 claimBatch Gas Usage");
   const table = new Table({
-    head: ["Ticket Batch Size", "Average Gas Per Ticket", "Total Gas Used"],
+    head: [
+      "Ticket Batch Size",
+      "Recipients",
+
+      "Average Gas Per Ticket",
+      "Total Gas Used",
+    ],
     colAligns: ["right", "right", "right"],
   });
   for (const scenario of scenarios) {
     const averagePerClaim = scenario.totalGasUsed
       .div(scenario.batchSize)
       .toNumber();
-    table.push([scenario.batchSize, averagePerClaim, scenario.totalGasUsed]);
+    table.push([
+      scenario.batchSize,
+      scenario.customer === "Unique" ? "Unique recipients" : "Same recipient",
+      averagePerClaim,
+      scenario.totalGasUsed,
+    ]);
   }
   console.log(table.toString());
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -5,31 +5,19 @@ import { ethers as ethersTypes } from "ethers";
 export type ScenarioGasUsage = {
   batchSize: number;
   totalGasUsed: BigNumber;
-  customer: "Unique" | "Same";
 };
 
 export function printScenarioGasUsage(scenarios: ScenarioGasUsage[]) {
   console.log("L1 claimBatch Gas Usage");
   const table = new Table({
-    head: [
-      "Ticket Batch Size",
-      "Recipients",
-
-      "Average Gas Per Ticket",
-      "Total Gas Used",
-    ],
+    head: ["Ticket Batch Size", "Average Gas Per Ticket", "Total Gas Used"],
     colAligns: ["right", "right", "right"],
   });
   for (const scenario of scenarios) {
     const averagePerClaim = scenario.totalGasUsed
       .div(scenario.batchSize)
       .toNumber();
-    table.push([
-      scenario.batchSize,
-      scenario.customer === "Unique" ? "Unique recipients" : "Same recipient",
-      averagePerClaim,
-      scenario.totalGasUsed,
-    ]);
+    table.push([scenario.batchSize, averagePerClaim, scenario.totalGasUsed]);
   }
   console.log(table.toString());
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,5 +1,6 @@
 import Table from "cli-table";
 import { BigNumber } from "ethers";
+import { ethers as ethersTypes } from "ethers";
 
 export type ScenarioGasUsage = {
   batchSize: number;
@@ -19,4 +20,19 @@ export function printScenarioGasUsage(scenarios: ScenarioGasUsage[]) {
     table.push([scenario.batchSize, averagePerClaim, scenario.totalGasUsed]);
   }
   console.log(table.toString());
+}
+// Address 0x2a47Cd5718D67Dc81eAfB24C99d4db159B0e7bCa
+export const customerPK =
+  "0xe1743f0184b85ac1412311be9d6e5d333df23e22efdf615d0135ca2b9ed67938";
+// Address 0x9552ceB4e6FA8c356c1A76A8Bc8b1EFA7B9fb205
+export const lpPK =
+  "0x23ac17b9c3590a8e67a1d1231ebab87dd2d3389d2f1526f842fd1326a0990f42";
+
+// pk = 0x91f47a1911c0fd985b34c25962f661f0de606f7ad38ba156902dff48b4d05f97
+export const customer2Address = "0xAAAB35381A38C4fF4967DC29470F0f2637295983";
+
+export async function waitForTx(
+  txPromise: Promise<ethersTypes.providers.TransactionResponse>
+) {
+  return (await txPromise).wait();
 }


### PR DESCRIPTION
Fixes #94.

This PR:
- Moves benchmarking to its own test file.`safe.test.ts` was starting to get quite large.
- Only call `claimBatch`  in the benchmark. This simplifies the benchmark and prevents L2 calls from influencing L1 gas calls via a shared token contract.
- Creates a unique receipt for every ticket. This results in a more realistic gas cost.

![image](https://user-images.githubusercontent.com/1620336/148452090-9ccd7929-93b2-449d-8b82-35fc801b40ef.png)

