### PR TITLE
Add basic L1<->L2 Token mapping

### DIFF
--- a/contracts/common.sol
+++ b/contracts/common.sol
@@ -3,9 +3,6 @@ pragma solidity ^0.8.10;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-address constant lpAddress = address(
-    0x9552ceB4e6FA8c356c1A76A8Bc8b1EFA7B9fb205
-);
 
 struct L1Ticket {
     /// Who will get the funds if executed

--- a/contracts/l1.sol
+++ b/contracts/l1.sol
@@ -5,18 +5,25 @@ import "./common.sol";
 
 contract l1 is SignatureChecker {
     uint256 nextNonce = 0;
+    // TODO: Eventually this should probably use a well-tested ownership library.
+    address owner;
 
     receive() external payable {}
 
-    function claimBatch(L1Ticket[] calldata tickets, Signature calldata signature)
-        public
-    {
+    constructor() {
+        owner = msg.sender;
+    }
+
+    function claimBatch(
+        L1Ticket[] calldata tickets,
+        Signature calldata signature
+    ) public {
         bytes32 message = keccak256(
             abi.encode(TicketsWithNonce(nextNonce, tickets))
         );
 
         require(
-            recoverSigner(message, signature) == lpAddress,
+            recoverSigner(message, signature) == owner,
             "Must be signed by liquidity provider"
         );
 

--- a/contracts/l2.sol
+++ b/contracts/l2.sol
@@ -52,8 +52,24 @@ contract L2 is SignatureChecker {
     mapping(address => address) public l2TokenMap;
     uint256 nextBatchStart = 0;
 
-    constructor(TokenPair[] memory pairs) {
+    // TODO: Eventually this should probably use a well-tested ownership library.
+    address owner;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    function registerTokenPairs(TokenPair[] memory pairs) public {
+        require(msg.sender == owner, "Only the owner can add token pairs");
         for (uint256 i = 0; i < pairs.length; i++) {
+            require(
+                l2TokenMap[pairs[i].l2Token] == address(0),
+                "A mapping exists for the L2 token"
+            );
+            require(
+                l1TokenMap[pairs[i].l1Token] == address(0),
+                "A mapping exists for the L1 token"
+            );
             l2TokenMap[pairs[i].l2Token] = pairs[i].l1Token;
             l1TokenMap[pairs[i].l1Token] = pairs[i].l2Token;
         }

--- a/contracts/l2.sol
+++ b/contracts/l2.sol
@@ -138,7 +138,7 @@ contract L2 is SignatureChecker {
 
         require(nextBatchStart == first, "Batches must be gapless");
         require(
-            recoverSigner(message, signature) == lpAddress,
+            recoverSigner(message, signature) == owner,
             "Must be signed by liquidity provider"
         );
         uint256 maxAuthTime = earliestTimestamp + maxAuthDelay;
@@ -196,7 +196,7 @@ contract L2 is SignatureChecker {
             Ticket memory ticket = tickets[i];
             // Since the ticket token is validated when it is registered, we can be sure that l1TokenMap[ticket.token])!= address(0)
             IERC20 tokenContract = IERC20(l1TokenMap[ticket.token]);
-            tokenContract.transfer(lpAddress, ticket.value);
+            tokenContract.transfer(owner, ticket.value);
         }
     }
 
@@ -225,7 +225,7 @@ contract L2 is SignatureChecker {
             "Honest and fraud indices must match"
         );
         require(
-            recoverSigner(message, fraudSignature) == lpAddress,
+            recoverSigner(message, fraudSignature) == owner,
             "Must be signed by liquidity provider"
         );
 

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -30,7 +30,26 @@ const tokenDeployer = new TestToken__factory(lpWallet);
 
 let lpL1: L1;
 let customerL2: L2, lpL2: L2;
-let testToken: TestToken;
+let l1TestToken: TestToken, l2TestToken: TestToken;
+
+async function approveAndDistributeTokens(
+  testToken: TestToken,
+  l1Address: string,
+  l2Address: string
+): Promise<void> {
+  // Transfer 1/4 to the customer account
+  await testToken.transfer(customerWallet.address, tokenBalance / 4);
+  // Transfer 1/4 to the l1 contract for payouts
+  await testToken.transfer(l1Address, tokenBalance / 4);
+  // Transfer 1/4 to the l2 contract for payouts
+  await testToken.transfer(l2Address, tokenBalance / 4);
+  // Approve transfers for the L1 and L2 contract for the LP
+  await testToken.approve(l2Address, tokenBalance);
+  await testToken.approve(l1Address, tokenBalance);
+  // Approve transfers for the L1 and L2 contract for the customer
+  await testToken.connect(customerWallet).approve(l1Address, tokenBalance);
+  await testToken.connect(customerWallet).approve(l2Address, tokenBalance);
+}
 
 async function deposit(trustedNonce: number, trustedAmount: number) {
   const depositAmount = 1;
@@ -39,7 +58,7 @@ async function deposit(trustedNonce: number, trustedAmount: number) {
     trustedAmount,
     depositAmount,
     l1Recipient: customerWallet.address,
-    token: testToken.address,
+    token: l2TestToken.address,
   };
   const deposit2: L2DepositStruct = {
     ...deposit,
@@ -57,7 +76,7 @@ async function depositOnce(trustedNonce: number, trustedAmount: number) {
     trustedAmount,
     depositAmount,
     l1Recipient: customerWallet.address,
-    token: testToken.address,
+    token: l2TestToken.address,
   };
 
   await waitForTx(customerL2.depositOnL2(deposit, { value: depositAmount }));
@@ -123,27 +142,20 @@ async function swap(
 }
 
 beforeEach(async () => {
+  l1TestToken = await tokenDeployer.deploy(tokenBalance);
+  l2TestToken = await tokenDeployer.deploy(tokenBalance);
   const l1 = await l1Deployer.deploy();
-  const l2 = await l2Deployer.deploy();
+  const l2 = await l2Deployer.deploy([
+    { l1Token: l1TestToken.address, l2Token: l2TestToken.address },
+  ]);
+
+  await approveAndDistributeTokens(l1TestToken, l1.address, l2.address);
+  await approveAndDistributeTokens(l2TestToken, l1.address, l2.address);
 
   customerL2 = l2.connect(customerWallet);
 
   lpL2 = l2.connect(lpWallet);
   lpL1 = l1.connect(lpWallet);
-
-  testToken = await tokenDeployer.deploy(tokenBalance);
-  // Transfer 1/4 to the customer account
-  await testToken.transfer(customerWallet.address, tokenBalance / 4);
-  // Transfer 1/4 to the l1 contract for payouts
-  await testToken.transfer(l1.address, tokenBalance / 4);
-  // Transfer 1/4 to the l2 contract for payouts
-  await testToken.transfer(l2.address, tokenBalance / 4);
-  // Approve transfers for the L1 and L2 contract for the LP
-  await testToken.approve(l2.address, tokenBalance);
-  await testToken.approve(l1.address, tokenBalance);
-  // Approve transfers for the L1 and L2 contract for the customer
-  await testToken.connect(customerWallet).approve(l1.address, tokenBalance);
-  await testToken.connect(customerWallet).approve(l2.address, tokenBalance);
 });
 
 it("One successfull e2e swaps", async () => {

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -34,21 +34,20 @@ let l1TestToken: TestToken, l2TestToken: TestToken;
 
 async function approveAndDistributeTokens(
   testToken: TestToken,
-  l1Address: string,
-  l2Address: string
+  contractAddress: string
 ): Promise<void> {
   // Transfer 1/4 to the customer account
   await testToken.transfer(customerWallet.address, tokenBalance / 4);
-  // Transfer 1/4 to the l1 contract for payouts
-  await testToken.transfer(l1Address, tokenBalance / 4);
-  // Transfer 1/4 to the l2 contract for payouts
-  await testToken.transfer(l2Address, tokenBalance / 4);
-  // Approve transfers for the L1 and L2 contract for the LP
-  await testToken.approve(l2Address, tokenBalance);
-  await testToken.approve(l1Address, tokenBalance);
-  // Approve transfers for the L1 and L2 contract for the customer
-  await testToken.connect(customerWallet).approve(l1Address, tokenBalance);
-  await testToken.connect(customerWallet).approve(l2Address, tokenBalance);
+  // Transfer 1/4 to the  contract for payouts
+  await testToken.transfer(contractAddress, tokenBalance / 4);
+
+  // Approve transfers for the contract
+  await testToken.approve(contractAddress, tokenBalance);
+
+  // Approve transfers for the contract for the customer
+  await testToken
+    .connect(customerWallet)
+    .approve(contractAddress, tokenBalance);
 }
 
 async function deposit(trustedNonce: number, trustedAmount: number) {
@@ -151,8 +150,8 @@ beforeEach(async () => {
     { l1Token: l1TestToken.address, l2Token: l2TestToken.address },
   ]);
 
-  await approveAndDistributeTokens(l1TestToken, l1.address, l2.address);
-  await approveAndDistributeTokens(l2TestToken, l1.address, l2.address);
+  await approveAndDistributeTokens(l1TestToken, l1.address);
+  await approveAndDistributeTokens(l2TestToken, l2.address);
 
   customerL2 = l2.connect(customerWallet);
 

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -145,7 +145,9 @@ beforeEach(async () => {
   l1TestToken = await tokenDeployer.deploy(tokenBalance);
   l2TestToken = await tokenDeployer.deploy(tokenBalance);
   const l1 = await l1Deployer.deploy();
-  const l2 = await l2Deployer.deploy([
+  const l2 = await l2Deployer.deploy();
+
+  await l2.registerTokenPairs([
     { l1Token: l1TestToken.address, l2Token: l2TestToken.address },
   ]);
 


### PR DESCRIPTION
Fixes #97 
Fixes #76

Previously we were using one ERC20 contract (and therefore one contract address) between both L1 and L2 contracts. In the real world there will be separate token contracts on L1 and L2 so we need a way of registering a map between the two corresponding token addresses.

This PR adds a `registerTokenPairs` function that stores a token pair on the L2 contract. Whenever a user deposits on L2 (with an L2 token) we use our token pair mapping to create a ticket with an L1 token address. If refund is called we look up   the L2 token address and then transfer that back.

To prevent any malicious use of `registerTokenPairs` there are two major restrictions:
1) Only the `owner` can call `registerTokenPairs`
2)`registerTokenPairs` can never override an existing token address.

To  allow 1) our contracts now set an `owner` field to the caller of the constructor. I've also applied this to the L1 contract to fix #76. 