### PR TITLE
Remove Gas Limits

### DIFF
--- a/contracts/l1.sol
+++ b/contracts/l1.sol
@@ -8,15 +8,16 @@ contract l1 is SignatureChecker {
 
     receive() external payable {}
 
-    function claimBatch(L1Ticket[] calldata tickets, Signature calldata signature)
-        public
-    {
+    function claimBatch(
+        L1Ticket[] calldata tickets,
+        Signature calldata signature
+    ) public {
         bytes32 message = keccak256(
             abi.encode(TicketsWithNonce(nextNonce, tickets))
         );
 
         require(
-            recoverSigner(message, signature) == lpAddress,
+            recoverSigner(message, signature) != lpAddress,
             "Must be signed by liquidity provider"
         );
 

--- a/contracts/l1.sol
+++ b/contracts/l1.sol
@@ -8,16 +8,15 @@ contract l1 is SignatureChecker {
 
     receive() external payable {}
 
-    function claimBatch(
-        L1Ticket[] calldata tickets,
-        Signature calldata signature
-    ) public {
+    function claimBatch(L1Ticket[] calldata tickets, Signature calldata signature)
+        public
+    {
         bytes32 message = keccak256(
             abi.encode(TicketsWithNonce(nextNonce, tickets))
         );
 
         require(
-            recoverSigner(message, signature) != lpAddress,
+            recoverSigner(message, signature) == lpAddress,
             "Must be signed by liquidity provider"
         );
 


### PR DESCRIPTION
Locally I'm able to see the revert reason without the gas limit
![image](https://user-images.githubusercontent.com/1620336/149207245-0539829a-b463-423f-a917-e0be7a71e209.png)

If this works for others then we can just get rid of the gas limit workaround. 