### PR TITLE
Slight Testing Refactor

### DIFF
--- a/test/benchmarking.test.ts
+++ b/test/benchmarking.test.ts
@@ -26,7 +26,7 @@ async function createCustomer(): Promise<string> {
   // We assume the customer currently holds, or has previously held, some of the ERC20 tokens on L1.
   // To simulate this we transfer a small amount of tokens to the customer's address, triggering the initial storage write.
   // This prevents the gas cost of claimBatch including a write to zero storage cost for the first time the customer receives tokens.
-  await l1Token.transfer(address, 1);
+  await waitForTx(l1Token.transfer(address, 1));
 
   return address;
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -106,7 +106,8 @@ async function approveAndDistribute(
 export async function deposit(
   setup: L2TestSetup,
   trustedNonce: number,
-  trustedAmount: number
+  trustedAmount: number,
+  l1Recipient?: string
 ) {
   const { customerWallet, l2Token, customerL2 } = setup;
   const depositAmount = 1;
@@ -114,35 +115,13 @@ export async function deposit(
     trustedNonce,
     trustedAmount,
     depositAmount,
-    l1Recipient: customerWallet.address,
-    token: l2Token.address,
-  };
-  const deposit2: L2DepositStruct = {
-    ...deposit,
-    l1Recipient: customer2Address,
-  };
-
-  await waitForTx(customerL2.depositOnL2(deposit, { value: depositAmount }));
-  await waitForTx(customerL2.depositOnL2(deposit2, { value: depositAmount }));
-}
-
-async function depositOnce(
-  setup: L2TestSetup,
-  trustedNonce: number,
-  trustedAmount: number
-) {
-  const { customerWallet, l2Token, customerL2 } = setup;
-  const depositAmount = 1;
-  const deposit: L2DepositStruct = {
-    trustedNonce,
-    trustedAmount,
-    depositAmount,
-    l1Recipient: customerWallet.address,
+    l1Recipient: l1Recipient || customerWallet.address,
     token: l2Token.address,
   };
 
   await waitForTx(customerL2.depositOnL2(deposit, { value: depositAmount }));
 }
+
 export async function authorizeWithdrawal(
   setup: L2TestSetup,
   trustedNonce: number,
@@ -197,7 +176,7 @@ export async function swap(
   numTickets = 2
 ) {
   for (let i = 0; i < numTickets; i++) {
-    await depositOnce(setup, trustedNonce, trustedAmount);
+    await deposit(setup, trustedNonce, trustedAmount);
   }
   const { tickets, signature } = await authorizeWithdrawal(
     setup,

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,6 +1,13 @@
 import Table from "cli-table";
-import { BigNumber } from "ethers";
+import { BigNumber, Wallet } from "ethers";
 import { ethers as ethersTypes } from "ethers";
+import { L1, L1TicketStruct } from "../contract-types/L1";
+import { L2, L2DepositStruct, TicketStruct } from "../contract-types/L2";
+import { TestToken } from "../contract-types/TestToken";
+import { TicketsWithNonce } from "../src/types";
+import { hashTickets, signData } from "../src/utils";
+import { ethers } from "hardhat";
+import { SAFETY_DELAY } from "../src/constants";
 
 export type ScenarioGasUsage = {
   batchSize: number;
@@ -35,4 +42,177 @@ export async function waitForTx(
   txPromise: Promise<ethersTypes.providers.TransactionResponse>
 ) {
   return (await txPromise).wait();
+}
+export type CommonTestSetup = {
+  customerWallet: ethersTypes.Wallet;
+  lpWallet: ethersTypes.Wallet;
+  tokenBalance: number;
+  gasLimit: number;
+};
+export type L1TestSetup = {
+  l1Token: TestToken;
+  lpL1: L1;
+} & CommonTestSetup;
+
+export type L2TestSetup = {
+  l2Token: TestToken;
+  lpL2: L2;
+  customerL2: L2;
+} & CommonTestSetup;
+
+export type TestSetup = L1TestSetup & L2TestSetup;
+
+export async function distributeL1Tokens(setup: L1TestSetup) {
+  const { l1Token, lpL1, customerWallet, tokenBalance } = setup;
+
+  await approveAndDistribute(
+    l1Token,
+    lpL1.address,
+    customerWallet,
+    tokenBalance
+  );
+}
+export async function distributeL2Tokens(setup: L2TestSetup) {
+  const { l2Token, lpL2, customerWallet, tokenBalance } = setup;
+  await approveAndDistribute(
+    l2Token,
+    lpL2.address,
+    customerWallet,
+    tokenBalance
+  );
+}
+
+async function approveAndDistribute(
+  testToken: TestToken,
+  contractAddress: string,
+  customerWallet: Wallet,
+  tokenBalance: number
+): Promise<void> {
+  // Transfer 1/4 to the customer account
+  await testToken.transfer(customerWallet.address, tokenBalance / 4);
+
+  // Transfer 1/4 to the  contract for payouts
+  await testToken.transfer(contractAddress, tokenBalance / 4);
+
+  // Approve transfers for the contract
+  await testToken.approve(contractAddress, tokenBalance);
+
+  // Approve transfers for the contract for the customer
+  await testToken
+    .connect(customerWallet)
+    .approve(contractAddress, tokenBalance);
+}
+
+export async function deposit(
+  setup: L2TestSetup,
+  trustedNonce: number,
+  trustedAmount: number
+) {
+  const { customerWallet, l2Token, customerL2 } = setup;
+  const depositAmount = 1;
+  const deposit: L2DepositStruct = {
+    trustedNonce,
+    trustedAmount,
+    depositAmount,
+    l1Recipient: customerWallet.address,
+    token: l2Token.address,
+  };
+  const deposit2: L2DepositStruct = {
+    ...deposit,
+    l1Recipient: customer2Address,
+  };
+
+  await waitForTx(customerL2.depositOnL2(deposit, { value: depositAmount }));
+  await waitForTx(customerL2.depositOnL2(deposit2, { value: depositAmount }));
+}
+
+async function depositOnce(
+  setup: L2TestSetup,
+  trustedNonce: number,
+  trustedAmount: number
+) {
+  const { customerWallet, l2Token, customerL2 } = setup;
+  const depositAmount = 1;
+  const deposit: L2DepositStruct = {
+    trustedNonce,
+    trustedAmount,
+    depositAmount,
+    l1Recipient: customerWallet.address,
+    token: l2Token.address,
+  };
+
+  await waitForTx(customerL2.depositOnL2(deposit, { value: depositAmount }));
+}
+export async function authorizeWithdrawal(
+  setup: L2TestSetup,
+  trustedNonce: number,
+  numTickets = 2
+): Promise<{ tickets: L1TicketStruct[]; signature: ethersTypes.Signature }> {
+  const { lpL2, gasLimit } = setup;
+
+  const tickets: L1TicketStruct[] = [];
+  for (let i = 0; i < numTickets; i++) {
+    tickets.push(ticketToL1Ticket(await lpL2.tickets(trustedNonce + i)));
+  }
+
+  const ticketsWithNonce: TicketsWithNonce = {
+    startNonce: trustedNonce,
+    tickets,
+  };
+  const signature = signData(hashTickets(ticketsWithNonce), lpPK);
+  await waitForTx(
+    lpL2.authorizeWithdrawal(
+      trustedNonce,
+      trustedNonce + numTickets - 1,
+      signature,
+      {
+        // TODO: remove this after addressing https://github.com/statechannels/SAFE-protocol/issues/70
+        gasLimit,
+      }
+    )
+  );
+  return { tickets, signature };
+}
+
+export function ticketToL1Ticket(ticket: TicketStruct): L1TicketStruct {
+  return {
+    value: ticket.value,
+    l1Recipient: ticket.l1Recipient,
+    token: ticket.token,
+  };
+}
+/**
+ *
+ * @param testSetup A TestSetup object that contains various contracts and wallets
+ * @param trustedNonce The sum of all tickets starting with trustedNonce + new deposit must be <= trustedAmount
+ * @param trustedAmount amount expected to be held on L1 contract
+ * @param numTickets number of tickets to include in the swap's batch
+ * @returns receipt of the L1 claimBatch transaction
+ */
+export async function swap(
+  setup: TestSetup,
+  trustedNonce: number,
+  trustedAmount: number,
+
+  numTickets = 2
+) {
+  for (let i = 0; i < numTickets; i++) {
+    await depositOnce(setup, trustedNonce, trustedAmount);
+  }
+  const { tickets, signature } = await authorizeWithdrawal(
+    setup,
+    trustedNonce,
+    numTickets
+  );
+  const { lpL1, gasLimit, lpL2 } = setup;
+  const l1TransactionReceipt = await waitForTx(
+    lpL1.claimBatch(tickets, signature, { gasLimit })
+  );
+
+  await ethers.provider.send("evm_increaseTime", [SAFETY_DELAY + 1]);
+  await waitForTx(lpL2.claimL2Funds(trustedNonce));
+
+  // TODO: This ought to estimate the total user cost. The cost of the L1 transaction
+  // is currently used as a rough estimate of the total user cost.
+  return l1TransactionReceipt;
 }


### PR DESCRIPTION
This refactors the test files a little bit so `utils.ts` contains more of the helper functions  that were in `safe.test.ts`. This helps reduce duplication between test files.

The helper functions are now decoupled from the contracts / addresses and instead accept a `TestSetup` object that contains the various contracts and addresses. 

This work was done so getting L2 gas estimates for #41 will require less copy and pasting. There's probably more that could be done in this refactor but I wanted to limit the time spent on this.