### PR TITLE
refactor: rename l2 to exit and l1 to enter

### DIFF
--- a/contracts/common.sol
+++ b/contracts/common.sol
@@ -3,10 +3,9 @@ pragma solidity ^0.8.10;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-
-struct L1Ticket {
+struct EntryTicket {
     /// Who will get the funds if executed
-    address l1Recipient;
+    address entryRecipient;
     /// The amount of funds to send.
     uint256 value;
     /// The address of the ERC20 token to use.
@@ -15,7 +14,7 @@ struct L1Ticket {
 
 struct Ticket {
     /// Who will get the funds if executed
-    address l1Recipient;
+    address entryRecipient;
     /// The amount of funds to send.
     uint256 value;
     /// The timestamp when the ticket was registered
@@ -26,7 +25,7 @@ struct Ticket {
 
 struct TicketsWithNonce {
     uint256 startNonce;
-    L1Ticket[] tickets;
+    EntryTicket[] tickets;
 }
 
 struct Signature {
@@ -47,11 +46,12 @@ abstract contract SignatureChecker {
         return ecrecover(prefixedHash, signature.v, signature.r, signature.s);
     }
 
-    function ticketsEqual(L1Ticket memory t1, L1Ticket memory t2)
+    function ticketsEqual(EntryTicket memory t1, EntryTicket memory t2)
         public
         pure
         returns (bool)
     {
-        return (t1.value == t2.value) && (t1.l1Recipient == t2.l1Recipient);
+        return
+            (t1.value == t2.value) && (t1.entryRecipient == t2.entryRecipient);
     }
 }

--- a/contracts/entry.sol
+++ b/contracts/entry.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.10;
 
 import "./common.sol";
 
-contract entry is SignatureChecker {
+contract Entry is SignatureChecker {
     uint256 nextNonce = 0;
     // TODO: Eventually this should probably use a well-tested ownership library.
     address owner;

--- a/contracts/entry.sol
+++ b/contracts/entry.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.10;
 
 import "./common.sol";
 
-contract l1 is SignatureChecker {
+contract entry is SignatureChecker {
     uint256 nextNonce = 0;
     // TODO: Eventually this should probably use a well-tested ownership library.
     address owner;
@@ -15,7 +15,7 @@ contract l1 is SignatureChecker {
     }
 
     function claimBatch(
-        L1Ticket[] calldata tickets,
+        EntryTicket[] calldata tickets,
         Signature calldata signature
     ) public {
         bytes32 message = keccak256(
@@ -29,7 +29,7 @@ contract l1 is SignatureChecker {
 
         for (uint256 i = 0; i < tickets.length; i++) {
             IERC20 tokenContract = IERC20(tickets[i].token);
-            tokenContract.transfer(tickets[i].l1Recipient, tickets[i].value);
+            tokenContract.transfer(tickets[i].entryRecipient, tickets[i].value);
         }
 
         nextNonce = nextNonce + tickets.length;

--- a/doc/SAFE.md
+++ b/doc/SAFE.md
@@ -2,7 +2,7 @@
 
 # Abstract
 
-In this paper, we introduce the Secure Asymmetric Frugal Exchange (SAFE) protocol for withdrawing funds from a layer 2 system (such as an optimistic roll-up) to a layer 1 system (such as Ethereum mainnet). SAFE drastically reduces cost compared to existing solutions while maintaining trustlessness and security. We demonstrate transfers with a marginal L1 overhead of under 1500 mainnet Ethereum gas per transfer, based on a preliminary Solidity prototype.
+In this paper, we introduce the Secure Asymmetric Frugal Exchange (SAFE) protocol for withdrawing funds from a layer 2 system (such as an optimistic roll-up) to a layer 1 system (such as Ethereum mainnet). SAFE drastically reduces cost compared to existing solutions while maintaining trustlessness and security. We demonstrate transfers with a marginal Entry overhead of under 1500 mainnet Ethereum gas per transfer, based on a preliminary Solidity prototype.
 
 # Overview
 
@@ -13,36 +13,36 @@ SAFE enables users (named Alice in this document) to quickly move tokens on a bl
 
 Thus, Alice's swap is serviced with `1 + 2/n` transactions on `Chain2` and `1/n` transactions on `Chain1`, where `n` is the number of swaps serviced per batch. (This is slightly inaccurate, since it ignores transactions required by Bob to move liquidity from `Chain2` back to `Chain1` and into the holdings contract. Liquidity moves are not required for each batch, so this inaccuracy is likely to be a rounding error.)
 
-_**Note:** The protocol is inspired by optimizing for a specific use case, where `Chain1` is mainnet Ethereum ("Layer 1", or L1), and `Chain2` is an optimistic roll-up (ORU) Layer 2, or L2. Users who want to withdraw funds from an ORU L2 must wait an extended period of time before accessing their funds on L1. For this reason, we refer to `Chain1` as Layer 1 (`L1`) and `Chain2` as Layer 2 (`L2`) for the remainder of this document._
+_**Note:** The protocol is inspired by optimizing for a specific use case, where `Chain1` is mainnet Ethereum ("Layer 1", or Entry), and `Chain2` is an optimistic roll-up (ORU) Layer 2, or Exit. Users who want to withdraw funds from an ORU Exit must wait an extended period of time before accessing their funds on Entry. For this reason, we refer to `Chain1` as Layer 1 (`Entry`) and `Chain2` as Layer 2 (`Exit`) for the remainder of this document._
 
-1. Alice deposits `x` tokens on L2, and is given a ticket `t`, which records that "`x` tokens should be sent to Alice on L1", which is initially in the `pending` state.
+1. Alice deposits `x` tokens on Exit, and is given a ticket `t`, which records that "`x` tokens should be sent to Alice on Entry", which is initially in the `pending` state.
 2. Bob then authorizes `t` by signing a special message `b` containing a batch of tickets, moving it into the `authorized` state.
-3. Once it's authorized, Alice _has the ability_ to submit `b` to L1, which sends `x` tokens to Alice. (Bob will probably submit `b` for expediency and convenience.) Bob is then forced to wait for a `SafetyWindow` timeout to pass
-4. After the `SafetyWindow` timeout passes, Bob can receive Alice's `x` tokens by calling `claimL2Batch(b)` on L2, which moves `t` into the `claimed` state.
+3. Once it's authorized, Alice _has the ability_ to submit `b` to Entry, which sends `x` tokens to Alice. (Bob will probably submit `b` for expediency and convenience.) Bob is then forced to wait for a `SafetyWindow` timeout to pass
+4. After the `SafetyWindow` timeout passes, Bob can receive Alice's `x` tokens by calling `claimExitBatch(b)` on Exit, which moves `t` into the `claimed` state.
 
 Two things can go majorly wrong:
 
 1. Bob might ghost Alice and never authorize a ticket. If Bob fails to authorize `t` within a certain time window, `AuthorizationWindow`, then Alice can reclaim `x` tokens, moving `t` to the `withdrawn` state.
-2. Bob can authorize `t` in a batch `b` on L2, but submit a different batch `b'` on L1. This is an attributable fault, since Bob promised he would only submit `b`. In this case, Alice can call `proveFraud(b')`, which sends `x` tokens back to Alice on L2 and moves `t` into the `withdrawn` state.
+2. Bob can authorize `t` in a batch `b` on Exit, but submit a different batch `b'` on Entry. This is an attributable fault, since Bob promised he would only submit `b`. In this case, Alice can call `proveFraud(b')`, which sends `x` tokens back to Alice on Exit and moves `t` into the `withdrawn` state.
 
 _**Observation:** SAFE is in fact very similar to a ORU: Alice's desired transaction is recorded in a queue in some smart contract on `Chain2`. Bob triggers a batch of transactions from this queue on `Chain1`. If Bob executes an incorrect batch on `Chain1`, any verifier can prove fraud on `Chain2`, and make users whole. ORUs work similarly to this, with `Chain2` being mainnet Ethereum, Bob being a "sequencer", and `Chain1` being a VM whose state results from applying the queued transactions from some initial state._
 
 # Security Claims
 
-We seek to make safety claims (S1)-(S2) and liveness claims (L1)-(L3) outlined below, based on the following assumptions:
+We seek to make safety claims (S1)-(S2) and liveness claims (Entry)-(L3) outlined below, based on the following assumptions:
 
 ## Assumptions
 
-- Users (Alice) and liquidity providers (Bob) are **_able to_** observe events on L1 in at most `t_observation_1` time and on L2 in at most `t_observation_2` time.
-- Users (Alice) and liquidity providers (Bob) are **_able to_** submit and get their transaction mined on L1 in at most `t_submission_1` time and on L2 in at most `t_submission_2` time.
+- Users (Alice) and liquidity providers (Bob) are **_able to_** observe events on Entry in at most `t_observation_1` time and on Exit in at most `t_observation_2` time.
+- Users (Alice) and liquidity providers (Bob) are **_able to_** submit and get their transaction mined on Entry in at most `t_submission_1` time and on Exit in at most `t_submission_2` time.
 - Nobody can forge signatures.
 
 ## Safety
 
-1. If Alice successfully deposits `x` tokens on L2, then Alice can guarantee that
-   - either Alice reclaims `x` tokens on L2
-   - or Alice receives `x` tokens on L1
-2. If Bob authorizes a ticket with amount `x` on L2, then Bob can guarantee that he can receive `x` tokens on L2.
+1. If Alice successfully deposits `x` tokens on Exit, then Alice can guarantee that
+   - either Alice reclaims `x` tokens on Exit
+   - or Alice receives `x` tokens on Entry
+2. If Bob authorizes a ticket with amount `x` on Exit, then Bob can guarantee that he can receive `x` tokens on Exit.
 
 ## Liveness
 
@@ -50,8 +50,8 @@ We seek to make safety claims (S1)-(S2) and liveness claims (L1)-(L3) outlined b
 
 **Note:** These actually encompass S1-S2.
 
-1. If Alice successfully deposits `x` tokens on L2, then Alice can guarantee that `x` tokens are sent to an address provided by Alice, either on L1 or L2, in time at most `t_access_alice`.
-2. If Bob has deposited `x` tokens on L1, he can guarantee access to a total of `x` tokens across L1 and L2 in time at most `t_access_bob`.
+1. If Alice successfully deposits `x` tokens on Exit, then Alice can guarantee that `x` tokens are sent to an address provided by Alice, either on Entry or Exit, in time at most `t_access_alice`.
+2. If Bob has deposited `x` tokens on Entry, he can guarantee access to a total of `x` tokens across Entry and Exit in time at most `t_access_bob`.
 
    In other words, Bob can recover his liquidity in a fixed amount of time.
 
@@ -63,16 +63,16 @@ One area of future research is using our [experience with TLA+](https://blog.sta
 
 # Ticket flow (Happy path)
 
-### 1. Alice locks up funds on L2 in escrow.
+### 1. Alice locks up funds on Exit in escrow.
 
-Alice supplies the amount she wishes to swap, as well as some information about L1 amounts that L2 can trust _when putting her ticket in the queue._ Essentially, she is asserting "I believe that there are at least `trustedAmount` tokens available on L1 for tickets with nonce greater than `trustedNonce`." (If Alice submits an unsafe `trustedAmount`, she risks giving some funds to Bob. However, she does not risk another user Amy's funds, since the value she submits does not affect Amy's safety checks.)
+Alice supplies the amount she wishes to swap, as well as some information about Entry amounts that Exit can trust _when putting her ticket in the queue._ Essentially, she is asserting "I believe that there are at least `trustedAmount` tokens available on Entry for tickets with nonce greater than `trustedNonce`." (If Alice submits an unsafe `trustedAmount`, she risks giving some funds to Bob. However, she does not risk another user Amy's funds, since the value she submits does not affect Amy's safety checks.)
 
 A ticket is registered with the next-available nonce, by appending it to the `Tickets` array. Before registering a ticket, the total obligations since `trustedNonce` are tallied in `amountReserved` and deducted from `trustedAmount`. If there are insufficient funds remaining, Alice's ticket is not registered and her deposit is refunded.
 
 ```jsx
 struct Ticket {
     /// Who will get the funds if executed
-    address l1Recipient;
+    address entryRecipient;
     /// The amount of funds to send.
     uint256 value;
     /// The timestamp when the ticket was registered
@@ -82,19 +82,19 @@ struct Ticket {
 // The nonce of the ticket is its index in the array.
 Ticket[] public tickets;
 
-struct L2Deposit {
-    // the nonce of the most recent "L1AmountAssertion" that Alice trusts
+struct ExitDeposit {
+    // the nonce of the most recent "EntryAmountAssertion" that Alice trusts
     uint256 trustedNonce;
-    // the amount that Alice believes to be available on L1 for tickets with
+    // the amount that Alice believes to be available on Entry for tickets with
     // nonce *greater than trustedNonce*
     uint256 trustedAmount;
-    // the amount Alice wishes to claim on L1
+    // the amount Alice wishes to claim on Entry
     uint256 depositAmount;
-    // Alice's address on L1
-    address l1Recipient;
+    // Alice's address on Entry
+    address entryRecipient;
 }
 
-function depositOnL2(L2Deposit calldata deposit) public payable {
+function depositOnExit(ExitDeposit calldata deposit) public payable {
     uint256 amountAvailable = deposit.trustedAmount;
     uint256 trustedNonce = deposit.trustedNonce;
 
@@ -104,7 +104,7 @@ function depositOnL2(L2Deposit calldata deposit) public payable {
     }
 
     // We don't allow tickets to be registered if there are not enough funds
-    // remaining on L1 after accounting for already registered tickets.
+    // remaining on Entry after accounting for already registered tickets.
     require(
         amountAvailable >= amountReserved + deposit.depositAmount,
         "Must have enough funds for ticket"
@@ -114,7 +114,7 @@ function depositOnL2(L2Deposit calldata deposit) public payable {
         "Value sent must match depositAmount"
     );
     Ticket memory ticket = Ticket({
-        l1Recipient: deposit.l1Recipient,
+        entryRecipient: deposit.entryRecipient,
         value: deposit.depositAmount,
         timestamp: block.timestamp
     });
@@ -124,7 +124,7 @@ function depositOnL2(L2Deposit calldata deposit) public payable {
 }
 ```
 
-### 2. Bob authorizes withdrawals on L2
+### 2. Bob authorizes withdrawals on Exit
 
 Bob provides a signature on a batch of tickets.
 
@@ -183,14 +183,14 @@ function authorizeWithdrawal(
 }
 ```
 
-Suppose Bob authorized one of Alice’s tickets `t` in a batch `b`. When `t` was registered, the L2 contract made sure that the tickets ahead of Alice would not drain the L1 contract before paying out `t` in full. Since the L1 contract’s funds can _only go down_ by submitting a batch `b'` of tickets signed by Bob, when Alice’s ticket gets registered, it’s either the case that:
+Suppose Bob authorized one of Alice’s tickets `t` in a batch `b`. When `t` was registered, the Exit contract made sure that the tickets ahead of Alice would not drain the Entry contract before paying out `t` in full. Since the Entry contract’s funds can _only go down_ by submitting a batch `b'` of tickets signed by Bob, when Alice’s ticket gets registered, it’s either the case that:
 
-- The batch `b` is submitted, and Alice receives `t.amount` tokens on L1
-- Bob signed and submitted a different batch `b' != b`. From L2’s point of view, this is an attributable fault, and when given proof of such a fault, tickets are refunded on L2.
+- The batch `b` is submitted, and Alice receives `t.amount` tokens on Entry
+- Bob signed and submitted a different batch `b' != b`. From Exit’s point of view, this is an attributable fault, and when given proof of such a fault, tickets are refunded on Exit.
 
 **_This is the key fact that makes SAFE safe._**
 
-### 3. Anyone calls `claimBatch` on L1
+### 3. Anyone calls `claimBatch` on Entry
 
 ```jsx
 uint256 nextNonce = 0;
@@ -207,7 +207,7 @@ function claimBatch(Ticket[] calldata tickets, Signature calldata signature)
     );
 
     for (uint256 i = 0; i < tickets.length; i++) {
-        tickets[i].l1Recipient.call{
+        tickets[i].entryRecipient.call{
             value: tickets[i].value
         }("");
     }
@@ -216,14 +216,14 @@ function claimBatch(Ticket[] calldata tickets, Signature calldata signature)
 }
 ```
 
-### 4. Bob claims his funds on L2.
+### 4. Bob claims his funds on Exit.
 
-We force Bob to wait `SafetyWindow` time before he can claim his L2 funds. This allows any user to ensure that the correct batch is submitted on L1. ⚠️If Bob submits an incorrect batch, users must rescue their funds before the `SafetyWindow` passes.⚠️
+We force Bob to wait `SafetyWindow` time before he can claim his Exit funds. This allows any user to ensure that the correct batch is submitted on Entry. ⚠️If Bob submits an incorrect batch, users must rescue their funds before the `SafetyWindow` passes.⚠️
 
 ```jsx
 uint256 constant safetyDelay;
 
-function claimL2Funds(uint256 first) public {
+function claimExitFunds(uint256 first) public {
     Batch memory batch = batches[first];
     require(
         batch.status == BatchStatus.Authorized,
@@ -241,13 +241,13 @@ function claimL2Funds(uint256 first) public {
 }
 ```
 
-### 5. Refunding on L2 after (provable) fraud
+### 5. Refunding on Exit after (provable) fraud
 
-When Bob calls `authorizeWithdrawal`, he is enabling anyone to claim a specific batch of tickets on L1.
+When Bob calls `authorizeWithdrawal`, he is enabling anyone to claim a specific batch of tickets on Entry.
 
 Bob has the unique ability to claim an _arbitrary_ batch of tickets. To do so, he would supply a signature on `batch2` for a different batch of tickets than those he authorized in step 2.
 
-Because L2 has recorded exactly which batch he claimed he would submit, this is an attributable fault on L2! This would let Alice reclaim her escrowed funds. A simple modification of the protocol could penalize Bob for misbehaviour, and compensate Alice for her frustration.
+Because Exit has recorded exactly which batch he claimed he would submit, this is an attributable fault on Exit! This would let Alice reclaim her escrowed funds. A simple modification of the protocol could penalize Bob for misbehaviour, and compensate Alice for her frustration.
 
 ```tsx
 function refundOnFraud(
@@ -285,7 +285,7 @@ function refundOnFraud(
     );
 
     for (uint256 i = honestStartNonce; i < honestBatch.numTickets; i++) {
-        tickets[i].l1Recipient.call{
+        tickets[i].entryRecipient.call{
             value: tickets[i].value
         }("");
     }
@@ -294,7 +294,7 @@ function refundOnFraud(
 }
 ```
 
-### 6. Alice reclaims escrow on L2
+### 6. Alice reclaims escrow on Exit
 
 In case Bob fails to perform step (2), we must allow Alice to recover her funds after a timeout.
 
@@ -314,7 +314,7 @@ function refund(uint256 index) public {
     batch.status = BatchStatus.Withdrawn;
     nextBatchStart = index + 1;
 
-    tickets[index].l1Recipient.call{
+    tickets[index].entryRecipient.call{
         value: tickets[index].value
     }("");
 }
@@ -322,7 +322,7 @@ function refund(uint256 index) public {
 
 # Security analysis
 
-**Claim:** Security properties S1-S2 and L1-L3 hold (found [here](https://www.notion.so/Desired-security-and-usability-properties-a07341b850274837ae48370e3e6b20e8)) with
+**Claim:** Security properties S1-S2 and Entry-L3 hold (found [here](https://www.notion.so/Desired-security-and-usability-properties-a07341b850274837ae48370e3e6b20e8)) with
 
 - `t_access_alice < AuthorizationWindow + t_observation_2 + t_submission_1 + t_observation_1 + t_submission_2`
 - `t_access_bob < t_submission_2 + max(2*t_submission_2 + SafetyWWindow, t_submission_1)`
@@ -336,51 +336,51 @@ Tickets are grouped into batches. A batch is a set of tickets whose nonce is in 
 
 Let's say Alice registered a ticket (A1) just before the batch window — let's say it gets included in the batch that Bob authorizes. Two things might happens:
 
-1. Bob _authorizes_ `ticket` in a batch `b` in step 2, before `AuthWindow` passes. This blocks Alice from triggering A6. At this point, the _only batch that can be legally claimed on L1_ is `b` itself. Anyone can call `claimBatch(b)`, because Bob signed `b` and submitted it to L2, so Alice can trigger [A3] if Bob does not submit [B3] himself.
-   1. If Bob does not sign a different batch `b_bad`, then nobody can call `claimBatch` with `b_bad`. Therefore, any transaction calling `claimBatch(b)` will succeed. Alice can submit this transaction, and can therefore receive her funds on L1. Bob can receive Alice's L2 tokens at step 4 (B4).
-   2. If Bob signs and submits a different batch `b_bad` in [B3'], then anyone can point out that Bob signed `b_bad` _after committing to only submitting `b`._ This act enables anyone to call `refundOnFraud`. In particular, Alice can trigger step 5, [A5] in the diagram below, which returns `x` tokens to Alice on L2.
+1. Bob _authorizes_ `ticket` in a batch `b` in step 2, before `AuthWindow` passes. This blocks Alice from triggering A6. At this point, the _only batch that can be legally claimed on Entry_ is `b` itself. Anyone can call `claimBatch(b)`, because Bob signed `b` and submitted it to Exit, so Alice can trigger [A3] if Bob does not submit [B3] himself.
+   1. If Bob does not sign a different batch `b_bad`, then nobody can call `claimBatch` with `b_bad`. Therefore, any transaction calling `claimBatch(b)` will succeed. Alice can submit this transaction, and can therefore receive her funds on Entry. Bob can receive Alice's Exit tokens at step 4 (B4).
+   2. If Bob signs and submits a different batch `b_bad` in [B3'], then anyone can point out that Bob signed `b_bad` _after committing to only submitting `b`._ This act enables anyone to call `refundOnFraud`. In particular, Alice can trigger step 5, [A5] in the diagram below, which returns `x` tokens to Alice on Exit.
 2. Bob _does not authorize `ticket` in a batch `b` in step 2._
 
-   If Bob does not authorize `ticket`, then after `AuthWindow`, Alice can point out on L2 that `ticket` has not been authorized, by observing that the latest ticket authorized has nonce less than `ticket.nonce`. (Remember, the L2 rules dictate that the _next batch authorized_ must start with the next ticket not-yet-authorized. Ie. there are no "gaps" in the set of authorized tickets.)
+   If Bob does not authorize `ticket`, then after `AuthWindow`, Alice can point out on Exit that `ticket` has not been authorized, by observing that the latest ticket authorized has nonce less than `ticket.nonce`. (Remember, the Exit rules dictate that the _next batch authorized_ must start with the next ticket not-yet-authorized. Ie. there are no "gaps" in the set of authorized tickets.)
 
-   In short, the rules say Bob must to authorize tickets within `AuthWindow`, and he failed to do so, L2 releases the funds to Alice.
+   In short, the rules say Bob must to authorize tickets within `AuthWindow`, and he failed to do so, Exit releases the funds to Alice.
 
 The following diagram outlines the happy path. The worst case is if (A1) is submitted at the start of a "batch window". It would take:
 
 - `batch_window` time for Bob to wait for tickets to accumulate.
-- `t_submission_1` time for Bob to submit the batch on L1. (Note that it's safe for Bob to submit the batch on L1 in [B3] in parallel with authorizing tickets on L2 in (B2).)
+- `t_submission_1` time for Bob to submit the batch on Entry. (Note that it's safe for Bob to submit the batch on Entry in [B3] in parallel with authorizing tickets on Exit in (B2).)
 
 So, for Alice `t_happy_path < batch_window + t_submission_1`.
 
-![**Happy path** — Bob submits the correct batch on L1 (B3), but Alice has the option to submit the batch.](img/safe-happy-path.jpg)
+![**Happy path** — Bob submits the correct batch on Entry (B3), but Alice has the option to submit the batch.](img/safe-happy-path.jpg)
 
-**Happy path** — Bob submits the correct batch on L1 (B3), but Alice has the option to submit the batch.
+**Happy path** — Bob submits the correct batch on Entry (B3), but Alice has the option to submit the batch.
 
-**(L1: Alice recovers her funds quickly)**
+**(Entry: Alice recovers her funds quickly)**
 
 The following diagram shows how long Alice's funds can be locked up:
 
 - Alice submits a deposit in (A1) just before the "batch window" closes.
 - Bob doesn't authorize tickets at the end of the batch window, but waits as long as possible to authorize a batch of tickets `b` in (B2) just before Alice can call `reclaimEscrow` in (A6). (Note that (B2) _prevents_ Alice from successfully calling `reclaimEscrow`, since Alice can only reclaim unauthorized tickets.)
-- Bob them submits an incorrect batch of tickets `b'` to L1 in [B3']. This must have happened within `t_observation_2 + t_submission_1` time, because Alice would presumably immediately submit `b` after seeing it posted to L2.
+- Bob them submits an incorrect batch of tickets `b'` to Entry in [B3']. This must have happened within `t_observation_2 + t_submission_1` time, because Alice would presumably immediately submit `b` after seeing it posted to Exit.
   - Note that Alice has detected that Bob is acting funny, because he waited as long as possible to authorize Alice's ticket.
 - It would take `t_observation_1` time for Alice to observe [B3'], plus `t_submission_2` time for Alice to call `proveFraud` in (A5).
 
 The total is `t_access_alice = AuthorizationWindow + t_observation_2 + t_submission_1 + t_observation_1 + t_submission_2`.
 
-Note that this proof depends on the following inequality: `SafetyWindow > t_observation_2 + t_submission_1 + t_observation_1 + t_submission_2`. This prevents Bob from submitting an incorrect batch `b'` to L1 in [B3'], then claiming L2 funds as though the batch `b` were submitted in [B3'].
+Note that this proof depends on the following inequality: `SafetyWindow > t_observation_2 + t_submission_1 + t_observation_1 + t_submission_2`. This prevents Bob from submitting an incorrect batch `b'` to Entry in [B3'], then claiming Exit funds as though the batch `b` were submitted in [B3'].
 
 ![**Bob cheats** by sneaking an incorrect batch in at [B3'], just after the authorization window closes. Alice promptly triggers (A5) well before SafetyWindow passes, guaranteeing that (A5) happens before (B4).](img/safe-sad-path.jpg)
 
 **Bob cheats** by sneaking an incorrect batch in at [B3'], just after the authorization window closes. Alice promptly triggers (A5) well before SafetyWindow passes, guaranteeing that (A5) happens before (B4).
 
-**(S2 + L2: Bob can be made whole quickly)**
+**(S2 + Exit: Bob can be made whole quickly)**
 
 Bob can simply register a ticket at any time (`t_submission_2`) for the amount of unspent funds after all previously registered tickets are serviced. (⚠️Let's assume the system allows this functionality⚠️)
 
-Once the ticket is registered, he can authorize a batch including that ticket (`t_submission_2`), wait `SafetyWWindow` time, and call `claimL2Funds`, another `t_submission_2` time.
+Once the ticket is registered, he can authorize a batch including that ticket (`t_submission_2`), wait `SafetyWWindow` time, and call `claimExitFunds`, another `t_submission_2` time.
 
-In parallel, he must also claim the batch on L1, requiring `t_submission_1` time.
+In parallel, he must also claim the batch on Entry, requiring `t_submission_1` time.
 
 This takes a total of `t_submission_2 + max(2*t_submission_2 + SafetyWindow, t_submission_1)` time.
 
@@ -388,7 +388,7 @@ This takes a total of `t_submission_2 + max(2*t_submission_2 + SafetyWindow, t_s
 
 We are prototyping this spec in this repo: [https://github.com/statechannels/SAFE-protocol/](https://github.com/statechannels/SAFE-protocol/). We would like to calculate in detail how our protocol scales with batching, comparing the cost of this approach to existing solutions.
 
-Since ORU transactions incur an L1 gas cost, we would like to estimate the total user cost of SAFE by calculating the average amount of calldata required per swap in the L2 transactions.
+Since ORU transactions incur an Entry gas cost, we would like to estimate the total user cost of SAFE by calculating the average amount of calldata required per swap in the Exit transactions.
 
 # Future work:
 

--- a/doc/SAFE.md
+++ b/doc/SAFE.md
@@ -2,7 +2,7 @@
 
 # Abstract
 
-In this paper, we introduce the Secure Asymmetric Frugal Exchange (SAFE) protocol for withdrawing funds from a layer 2 system (such as an optimistic roll-up) to a layer 1 system (such as Ethereum mainnet). SAFE drastically reduces cost compared to existing solutions while maintaining trustlessness and security. We demonstrate transfers with a marginal Entry overhead of under 1500 mainnet Ethereum gas per transfer, based on a preliminary Solidity prototype.
+In this paper, we introduce the Secure Asymmetric Frugal Exchange (SAFE) protocol for withdrawing funds from a layer 2 system (such as an optimistic roll-up) to a layer 1 system (such as Ethereum mainnet). SAFE drastically reduces cost compared to existing solutions while maintaining trustlessness and security. We demonstrate transfers with a marginal L1 overhead of under 1500 mainnet Ethereum gas per transfer, based on a preliminary Solidity prototype.
 
 # Overview
 
@@ -13,36 +13,36 @@ SAFE enables users (named Alice in this document) to quickly move tokens on a bl
 
 Thus, Alice's swap is serviced with `1 + 2/n` transactions on `Chain2` and `1/n` transactions on `Chain1`, where `n` is the number of swaps serviced per batch. (This is slightly inaccurate, since it ignores transactions required by Bob to move liquidity from `Chain2` back to `Chain1` and into the holdings contract. Liquidity moves are not required for each batch, so this inaccuracy is likely to be a rounding error.)
 
-_**Note:** The protocol is inspired by optimizing for a specific use case, where `Chain1` is mainnet Ethereum ("Layer 1", or Entry), and `Chain2` is an optimistic roll-up (ORU) Layer 2, or Exit. Users who want to withdraw funds from an ORU Exit must wait an extended period of time before accessing their funds on Entry. For this reason, we refer to `Chain1` as Layer 1 (`Entry`) and `Chain2` as Layer 2 (`Exit`) for the remainder of this document._
+_**Note:** The protocol is inspired by optimizing for a specific use case, where `Chain1` is mainnet Ethereum ("Layer 1", or L1), and `Chain2` is an optimistic roll-up (ORU) Layer 2, or L2. Users who want to withdraw funds from an ORU L2 must wait an extended period of time before accessing their funds on L1. For this reason, we refer to `Chain1` as Layer 1 (`L1`) and `Chain2` as Layer 2 (`L2`) for the remainder of this document._
 
-1. Alice deposits `x` tokens on Exit, and is given a ticket `t`, which records that "`x` tokens should be sent to Alice on Entry", which is initially in the `pending` state.
+1. Alice deposits `x` tokens on L2, and is given a ticket `t`, which records that "`x` tokens should be sent to Alice on L1", which is initially in the `pending` state.
 2. Bob then authorizes `t` by signing a special message `b` containing a batch of tickets, moving it into the `authorized` state.
-3. Once it's authorized, Alice _has the ability_ to submit `b` to Entry, which sends `x` tokens to Alice. (Bob will probably submit `b` for expediency and convenience.) Bob is then forced to wait for a `SafetyWindow` timeout to pass
-4. After the `SafetyWindow` timeout passes, Bob can receive Alice's `x` tokens by calling `claimExitBatch(b)` on Exit, which moves `t` into the `claimed` state.
+3. Once it's authorized, Alice _has the ability_ to submit `b` to L1, which sends `x` tokens to Alice. (Bob will probably submit `b` for expediency and convenience.) Bob is then forced to wait for a `SafetyWindow` timeout to pass
+4. After the `SafetyWindow` timeout passes, Bob can receive Alice's `x` tokens by calling `claimL2Batch(b)` on L2, which moves `t` into the `claimed` state.
 
 Two things can go majorly wrong:
 
 1. Bob might ghost Alice and never authorize a ticket. If Bob fails to authorize `t` within a certain time window, `AuthorizationWindow`, then Alice can reclaim `x` tokens, moving `t` to the `withdrawn` state.
-2. Bob can authorize `t` in a batch `b` on Exit, but submit a different batch `b'` on Entry. This is an attributable fault, since Bob promised he would only submit `b`. In this case, Alice can call `proveFraud(b')`, which sends `x` tokens back to Alice on Exit and moves `t` into the `withdrawn` state.
+2. Bob can authorize `t` in a batch `b` on L2, but submit a different batch `b'` on L1. This is an attributable fault, since Bob promised he would only submit `b`. In this case, Alice can call `proveFraud(b')`, which sends `x` tokens back to Alice on L2 and moves `t` into the `withdrawn` state.
 
 _**Observation:** SAFE is in fact very similar to a ORU: Alice's desired transaction is recorded in a queue in some smart contract on `Chain2`. Bob triggers a batch of transactions from this queue on `Chain1`. If Bob executes an incorrect batch on `Chain1`, any verifier can prove fraud on `Chain2`, and make users whole. ORUs work similarly to this, with `Chain2` being mainnet Ethereum, Bob being a "sequencer", and `Chain1` being a VM whose state results from applying the queued transactions from some initial state._
 
 # Security Claims
 
-We seek to make safety claims (S1)-(S2) and liveness claims (Entry)-(L3) outlined below, based on the following assumptions:
+We seek to make safety claims (S1)-(S2) and liveness claims (L1)-(L3) outlined below, based on the following assumptions:
 
 ## Assumptions
 
-- Users (Alice) and liquidity providers (Bob) are **_able to_** observe events on Entry in at most `t_observation_1` time and on Exit in at most `t_observation_2` time.
-- Users (Alice) and liquidity providers (Bob) are **_able to_** submit and get their transaction mined on Entry in at most `t_submission_1` time and on Exit in at most `t_submission_2` time.
+- Users (Alice) and liquidity providers (Bob) are **_able to_** observe events on L1 in at most `t_observation_1` time and on L2 in at most `t_observation_2` time.
+- Users (Alice) and liquidity providers (Bob) are **_able to_** submit and get their transaction mined on L1 in at most `t_submission_1` time and on L2 in at most `t_submission_2` time.
 - Nobody can forge signatures.
 
 ## Safety
 
-1. If Alice successfully deposits `x` tokens on Exit, then Alice can guarantee that
-   - either Alice reclaims `x` tokens on Exit
-   - or Alice receives `x` tokens on Entry
-2. If Bob authorizes a ticket with amount `x` on Exit, then Bob can guarantee that he can receive `x` tokens on Exit.
+1. If Alice successfully deposits `x` tokens on L2, then Alice can guarantee that
+   - either Alice reclaims `x` tokens on L2
+   - or Alice receives `x` tokens on L1
+2. If Bob authorizes a ticket with amount `x` on L2, then Bob can guarantee that he can receive `x` tokens on L2.
 
 ## Liveness
 
@@ -50,8 +50,8 @@ We seek to make safety claims (S1)-(S2) and liveness claims (Entry)-(L3) outline
 
 **Note:** These actually encompass S1-S2.
 
-1. If Alice successfully deposits `x` tokens on Exit, then Alice can guarantee that `x` tokens are sent to an address provided by Alice, either on Entry or Exit, in time at most `t_access_alice`.
-2. If Bob has deposited `x` tokens on Entry, he can guarantee access to a total of `x` tokens across Entry and Exit in time at most `t_access_bob`.
+1. If Alice successfully deposits `x` tokens on L2, then Alice can guarantee that `x` tokens are sent to an address provided by Alice, either on L1 or L2, in time at most `t_access_alice`.
+2. If Bob has deposited `x` tokens on L1, he can guarantee access to a total of `x` tokens across L1 and L2 in time at most `t_access_bob`.
 
    In other words, Bob can recover his liquidity in a fixed amount of time.
 
@@ -63,16 +63,16 @@ One area of future research is using our [experience with TLA+](https://blog.sta
 
 # Ticket flow (Happy path)
 
-### 1. Alice locks up funds on Exit in escrow.
+### 1. Alice locks up funds on L2 in escrow.
 
-Alice supplies the amount she wishes to swap, as well as some information about Entry amounts that Exit can trust _when putting her ticket in the queue._ Essentially, she is asserting "I believe that there are at least `trustedAmount` tokens available on Entry for tickets with nonce greater than `trustedNonce`." (If Alice submits an unsafe `trustedAmount`, she risks giving some funds to Bob. However, she does not risk another user Amy's funds, since the value she submits does not affect Amy's safety checks.)
+Alice supplies the amount she wishes to swap, as well as some information about L1 amounts that L2 can trust _when putting her ticket in the queue._ Essentially, she is asserting "I believe that there are at least `trustedAmount` tokens available on L1 for tickets with nonce greater than `trustedNonce`." (If Alice submits an unsafe `trustedAmount`, she risks giving some funds to Bob. However, she does not risk another user Amy's funds, since the value she submits does not affect Amy's safety checks.)
 
 A ticket is registered with the next-available nonce, by appending it to the `Tickets` array. Before registering a ticket, the total obligations since `trustedNonce` are tallied in `amountReserved` and deducted from `trustedAmount`. If there are insufficient funds remaining, Alice's ticket is not registered and her deposit is refunded.
 
 ```jsx
 struct Ticket {
     /// Who will get the funds if executed
-    address entryRecipient;
+    address l1Recipient;
     /// The amount of funds to send.
     uint256 value;
     /// The timestamp when the ticket was registered
@@ -82,19 +82,19 @@ struct Ticket {
 // The nonce of the ticket is its index in the array.
 Ticket[] public tickets;
 
-struct ExitDeposit {
-    // the nonce of the most recent "EntryAmountAssertion" that Alice trusts
+struct L2Deposit {
+    // the nonce of the most recent "L1AmountAssertion" that Alice trusts
     uint256 trustedNonce;
-    // the amount that Alice believes to be available on Entry for tickets with
+    // the amount that Alice believes to be available on L1 for tickets with
     // nonce *greater than trustedNonce*
     uint256 trustedAmount;
-    // the amount Alice wishes to claim on Entry
+    // the amount Alice wishes to claim on L1
     uint256 depositAmount;
-    // Alice's address on Entry
-    address entryRecipient;
+    // Alice's address on L1
+    address l1Recipient;
 }
 
-function depositOnExit(ExitDeposit calldata deposit) public payable {
+function depositOnL2(L2Deposit calldata deposit) public payable {
     uint256 amountAvailable = deposit.trustedAmount;
     uint256 trustedNonce = deposit.trustedNonce;
 
@@ -104,7 +104,7 @@ function depositOnExit(ExitDeposit calldata deposit) public payable {
     }
 
     // We don't allow tickets to be registered if there are not enough funds
-    // remaining on Entry after accounting for already registered tickets.
+    // remaining on L1 after accounting for already registered tickets.
     require(
         amountAvailable >= amountReserved + deposit.depositAmount,
         "Must have enough funds for ticket"
@@ -114,7 +114,7 @@ function depositOnExit(ExitDeposit calldata deposit) public payable {
         "Value sent must match depositAmount"
     );
     Ticket memory ticket = Ticket({
-        entryRecipient: deposit.entryRecipient,
+        l1Recipient: deposit.l1Recipient,
         value: deposit.depositAmount,
         timestamp: block.timestamp
     });
@@ -124,7 +124,7 @@ function depositOnExit(ExitDeposit calldata deposit) public payable {
 }
 ```
 
-### 2. Bob authorizes withdrawals on Exit
+### 2. Bob authorizes withdrawals on L2
 
 Bob provides a signature on a batch of tickets.
 
@@ -183,14 +183,14 @@ function authorizeWithdrawal(
 }
 ```
 
-Suppose Bob authorized one of Alice’s tickets `t` in a batch `b`. When `t` was registered, the Exit contract made sure that the tickets ahead of Alice would not drain the Entry contract before paying out `t` in full. Since the Entry contract’s funds can _only go down_ by submitting a batch `b'` of tickets signed by Bob, when Alice’s ticket gets registered, it’s either the case that:
+Suppose Bob authorized one of Alice’s tickets `t` in a batch `b`. When `t` was registered, the L2 contract made sure that the tickets ahead of Alice would not drain the L1 contract before paying out `t` in full. Since the L1 contract’s funds can _only go down_ by submitting a batch `b'` of tickets signed by Bob, when Alice’s ticket gets registered, it’s either the case that:
 
-- The batch `b` is submitted, and Alice receives `t.amount` tokens on Entry
-- Bob signed and submitted a different batch `b' != b`. From Exit’s point of view, this is an attributable fault, and when given proof of such a fault, tickets are refunded on Exit.
+- The batch `b` is submitted, and Alice receives `t.amount` tokens on L1
+- Bob signed and submitted a different batch `b' != b`. From L2’s point of view, this is an attributable fault, and when given proof of such a fault, tickets are refunded on L2.
 
 **_This is the key fact that makes SAFE safe._**
 
-### 3. Anyone calls `claimBatch` on Entry
+### 3. Anyone calls `claimBatch` on L1
 
 ```jsx
 uint256 nextNonce = 0;
@@ -207,7 +207,7 @@ function claimBatch(Ticket[] calldata tickets, Signature calldata signature)
     );
 
     for (uint256 i = 0; i < tickets.length; i++) {
-        tickets[i].entryRecipient.call{
+        tickets[i].l1Recipient.call{
             value: tickets[i].value
         }("");
     }
@@ -216,14 +216,14 @@ function claimBatch(Ticket[] calldata tickets, Signature calldata signature)
 }
 ```
 
-### 4. Bob claims his funds on Exit.
+### 4. Bob claims his funds on L2.
 
-We force Bob to wait `SafetyWindow` time before he can claim his Exit funds. This allows any user to ensure that the correct batch is submitted on Entry. ⚠️If Bob submits an incorrect batch, users must rescue their funds before the `SafetyWindow` passes.⚠️
+We force Bob to wait `SafetyWindow` time before he can claim his L2 funds. This allows any user to ensure that the correct batch is submitted on L1. ⚠️If Bob submits an incorrect batch, users must rescue their funds before the `SafetyWindow` passes.⚠️
 
 ```jsx
 uint256 constant safetyDelay;
 
-function claimExitFunds(uint256 first) public {
+function claimL2Funds(uint256 first) public {
     Batch memory batch = batches[first];
     require(
         batch.status == BatchStatus.Authorized,
@@ -241,13 +241,13 @@ function claimExitFunds(uint256 first) public {
 }
 ```
 
-### 5. Refunding on Exit after (provable) fraud
+### 5. Refunding on L2 after (provable) fraud
 
-When Bob calls `authorizeWithdrawal`, he is enabling anyone to claim a specific batch of tickets on Entry.
+When Bob calls `authorizeWithdrawal`, he is enabling anyone to claim a specific batch of tickets on L1.
 
 Bob has the unique ability to claim an _arbitrary_ batch of tickets. To do so, he would supply a signature on `batch2` for a different batch of tickets than those he authorized in step 2.
 
-Because Exit has recorded exactly which batch he claimed he would submit, this is an attributable fault on Exit! This would let Alice reclaim her escrowed funds. A simple modification of the protocol could penalize Bob for misbehaviour, and compensate Alice for her frustration.
+Because L2 has recorded exactly which batch he claimed he would submit, this is an attributable fault on L2! This would let Alice reclaim her escrowed funds. A simple modification of the protocol could penalize Bob for misbehaviour, and compensate Alice for her frustration.
 
 ```tsx
 function refundOnFraud(
@@ -285,7 +285,7 @@ function refundOnFraud(
     );
 
     for (uint256 i = honestStartNonce; i < honestBatch.numTickets; i++) {
-        tickets[i].entryRecipient.call{
+        tickets[i].l1Recipient.call{
             value: tickets[i].value
         }("");
     }
@@ -294,7 +294,7 @@ function refundOnFraud(
 }
 ```
 
-### 6. Alice reclaims escrow on Exit
+### 6. Alice reclaims escrow on L2
 
 In case Bob fails to perform step (2), we must allow Alice to recover her funds after a timeout.
 
@@ -314,7 +314,7 @@ function refund(uint256 index) public {
     batch.status = BatchStatus.Withdrawn;
     nextBatchStart = index + 1;
 
-    tickets[index].entryRecipient.call{
+    tickets[index].l1Recipient.call{
         value: tickets[index].value
     }("");
 }
@@ -322,7 +322,7 @@ function refund(uint256 index) public {
 
 # Security analysis
 
-**Claim:** Security properties S1-S2 and Entry-L3 hold (found [here](https://www.notion.so/Desired-security-and-usability-properties-a07341b850274837ae48370e3e6b20e8)) with
+**Claim:** Security properties S1-S2 and L1-L3 hold (found [here](https://www.notion.so/Desired-security-and-usability-properties-a07341b850274837ae48370e3e6b20e8)) with
 
 - `t_access_alice < AuthorizationWindow + t_observation_2 + t_submission_1 + t_observation_1 + t_submission_2`
 - `t_access_bob < t_submission_2 + max(2*t_submission_2 + SafetyWWindow, t_submission_1)`
@@ -336,51 +336,51 @@ Tickets are grouped into batches. A batch is a set of tickets whose nonce is in 
 
 Let's say Alice registered a ticket (A1) just before the batch window — let's say it gets included in the batch that Bob authorizes. Two things might happens:
 
-1. Bob _authorizes_ `ticket` in a batch `b` in step 2, before `AuthWindow` passes. This blocks Alice from triggering A6. At this point, the _only batch that can be legally claimed on Entry_ is `b` itself. Anyone can call `claimBatch(b)`, because Bob signed `b` and submitted it to Exit, so Alice can trigger [A3] if Bob does not submit [B3] himself.
-   1. If Bob does not sign a different batch `b_bad`, then nobody can call `claimBatch` with `b_bad`. Therefore, any transaction calling `claimBatch(b)` will succeed. Alice can submit this transaction, and can therefore receive her funds on Entry. Bob can receive Alice's Exit tokens at step 4 (B4).
-   2. If Bob signs and submits a different batch `b_bad` in [B3'], then anyone can point out that Bob signed `b_bad` _after committing to only submitting `b`._ This act enables anyone to call `refundOnFraud`. In particular, Alice can trigger step 5, [A5] in the diagram below, which returns `x` tokens to Alice on Exit.
+1. Bob _authorizes_ `ticket` in a batch `b` in step 2, before `AuthWindow` passes. This blocks Alice from triggering A6. At this point, the _only batch that can be legally claimed on L1_ is `b` itself. Anyone can call `claimBatch(b)`, because Bob signed `b` and submitted it to L2, so Alice can trigger [A3] if Bob does not submit [B3] himself.
+   1. If Bob does not sign a different batch `b_bad`, then nobody can call `claimBatch` with `b_bad`. Therefore, any transaction calling `claimBatch(b)` will succeed. Alice can submit this transaction, and can therefore receive her funds on L1. Bob can receive Alice's L2 tokens at step 4 (B4).
+   2. If Bob signs and submits a different batch `b_bad` in [B3'], then anyone can point out that Bob signed `b_bad` _after committing to only submitting `b`._ This act enables anyone to call `refundOnFraud`. In particular, Alice can trigger step 5, [A5] in the diagram below, which returns `x` tokens to Alice on L2.
 2. Bob _does not authorize `ticket` in a batch `b` in step 2._
 
-   If Bob does not authorize `ticket`, then after `AuthWindow`, Alice can point out on Exit that `ticket` has not been authorized, by observing that the latest ticket authorized has nonce less than `ticket.nonce`. (Remember, the Exit rules dictate that the _next batch authorized_ must start with the next ticket not-yet-authorized. Ie. there are no "gaps" in the set of authorized tickets.)
+   If Bob does not authorize `ticket`, then after `AuthWindow`, Alice can point out on L2 that `ticket` has not been authorized, by observing that the latest ticket authorized has nonce less than `ticket.nonce`. (Remember, the L2 rules dictate that the _next batch authorized_ must start with the next ticket not-yet-authorized. Ie. there are no "gaps" in the set of authorized tickets.)
 
-   In short, the rules say Bob must to authorize tickets within `AuthWindow`, and he failed to do so, Exit releases the funds to Alice.
+   In short, the rules say Bob must to authorize tickets within `AuthWindow`, and he failed to do so, L2 releases the funds to Alice.
 
 The following diagram outlines the happy path. The worst case is if (A1) is submitted at the start of a "batch window". It would take:
 
 - `batch_window` time for Bob to wait for tickets to accumulate.
-- `t_submission_1` time for Bob to submit the batch on Entry. (Note that it's safe for Bob to submit the batch on Entry in [B3] in parallel with authorizing tickets on Exit in (B2).)
+- `t_submission_1` time for Bob to submit the batch on L1. (Note that it's safe for Bob to submit the batch on L1 in [B3] in parallel with authorizing tickets on L2 in (B2).)
 
 So, for Alice `t_happy_path < batch_window + t_submission_1`.
 
-![**Happy path** — Bob submits the correct batch on Entry (B3), but Alice has the option to submit the batch.](img/safe-happy-path.jpg)
+![**Happy path** — Bob submits the correct batch on L1 (B3), but Alice has the option to submit the batch.](img/safe-happy-path.jpg)
 
-**Happy path** — Bob submits the correct batch on Entry (B3), but Alice has the option to submit the batch.
+**Happy path** — Bob submits the correct batch on L1 (B3), but Alice has the option to submit the batch.
 
-**(Entry: Alice recovers her funds quickly)**
+**(L1: Alice recovers her funds quickly)**
 
 The following diagram shows how long Alice's funds can be locked up:
 
 - Alice submits a deposit in (A1) just before the "batch window" closes.
 - Bob doesn't authorize tickets at the end of the batch window, but waits as long as possible to authorize a batch of tickets `b` in (B2) just before Alice can call `reclaimEscrow` in (A6). (Note that (B2) _prevents_ Alice from successfully calling `reclaimEscrow`, since Alice can only reclaim unauthorized tickets.)
-- Bob them submits an incorrect batch of tickets `b'` to Entry in [B3']. This must have happened within `t_observation_2 + t_submission_1` time, because Alice would presumably immediately submit `b` after seeing it posted to Exit.
+- Bob them submits an incorrect batch of tickets `b'` to L1 in [B3']. This must have happened within `t_observation_2 + t_submission_1` time, because Alice would presumably immediately submit `b` after seeing it posted to L2.
   - Note that Alice has detected that Bob is acting funny, because he waited as long as possible to authorize Alice's ticket.
 - It would take `t_observation_1` time for Alice to observe [B3'], plus `t_submission_2` time for Alice to call `proveFraud` in (A5).
 
 The total is `t_access_alice = AuthorizationWindow + t_observation_2 + t_submission_1 + t_observation_1 + t_submission_2`.
 
-Note that this proof depends on the following inequality: `SafetyWindow > t_observation_2 + t_submission_1 + t_observation_1 + t_submission_2`. This prevents Bob from submitting an incorrect batch `b'` to Entry in [B3'], then claiming Exit funds as though the batch `b` were submitted in [B3'].
+Note that this proof depends on the following inequality: `SafetyWindow > t_observation_2 + t_submission_1 + t_observation_1 + t_submission_2`. This prevents Bob from submitting an incorrect batch `b'` to L1 in [B3'], then claiming L2 funds as though the batch `b` were submitted in [B3'].
 
 ![**Bob cheats** by sneaking an incorrect batch in at [B3'], just after the authorization window closes. Alice promptly triggers (A5) well before SafetyWindow passes, guaranteeing that (A5) happens before (B4).](img/safe-sad-path.jpg)
 
 **Bob cheats** by sneaking an incorrect batch in at [B3'], just after the authorization window closes. Alice promptly triggers (A5) well before SafetyWindow passes, guaranteeing that (A5) happens before (B4).
 
-**(S2 + Exit: Bob can be made whole quickly)**
+**(S2 + L2: Bob can be made whole quickly)**
 
 Bob can simply register a ticket at any time (`t_submission_2`) for the amount of unspent funds after all previously registered tickets are serviced. (⚠️Let's assume the system allows this functionality⚠️)
 
-Once the ticket is registered, he can authorize a batch including that ticket (`t_submission_2`), wait `SafetyWWindow` time, and call `claimExitFunds`, another `t_submission_2` time.
+Once the ticket is registered, he can authorize a batch including that ticket (`t_submission_2`), wait `SafetyWWindow` time, and call `claimL2Funds`, another `t_submission_2` time.
 
-In parallel, he must also claim the batch on Entry, requiring `t_submission_1` time.
+In parallel, he must also claim the batch on L1, requiring `t_submission_1` time.
 
 This takes a total of `t_submission_2 + max(2*t_submission_2 + SafetyWindow, t_submission_1)` time.
 
@@ -388,7 +388,7 @@ This takes a total of `t_submission_2 + max(2*t_submission_2 + SafetyWindow, t_s
 
 We are prototyping this spec in this repo: [https://github.com/statechannels/SAFE-protocol/](https://github.com/statechannels/SAFE-protocol/). We would like to calculate in detail how our protocol scales with batching, comparing the cost of this approach to existing solutions.
 
-Since ORU transactions incur an Entry gas cost, we would like to estimate the total user cost of SAFE by calculating the average amount of calldata required per swap in the Exit transactions.
+Since ORU transactions incur an L1 gas cost, we would like to estimate the total user cost of SAFE by calculating the average amount of calldata required per swap in the L2 transactions.
 
 # Future work:
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const SIGNED_SWAPS_ABI_TYPE = [
-  "tuple(uint256 startNonce, tuple(address l1Recipient, uint256 value, address token)[]) ",
+  "tuple(uint256 startNonce, tuple(address entryRecipient, uint256 value, address token)[]) ",
 ];
 
 export const USE_ERC20 = process.env.USE_ERC20 === "true";
@@ -7,6 +7,6 @@ export const USE_ERC20 = process.env.USE_ERC20 === "true";
 export const ETH_TOKEN_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 // It is VERY important that these values match the values in
-// l2.sol
+// exit.sol
 export const MAX_AUTH_DELAY = 600;
 export const SAFETY_DELAY = 600;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { TicketStruct } from "../contract-types/L1";
+import { TicketStruct } from "../contract-types/Entry";
 
 export type TicketsWithNonce = {
   startNonce: number;

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -4,8 +4,8 @@ chai.use(chaiAsPromised);
 
 import { ethers } from "hardhat";
 
-import { L1__factory } from "../contract-types/factories/L1__factory";
-import { L2__factory } from "../contract-types/factories/L2__factory";
+import { Entry__factory } from "../contract-types/factories/Entry__factory";
+import { Exit__factory } from "../contract-types/factories/Exit__factory";
 
 import { TestToken__factory } from "../contract-types/factories/TestToken__factory";
 
@@ -17,12 +17,12 @@ import {
   customer2Address,
   customerPK,
   deposit,
-  distributeL1Tokens,
-  distributeL2Tokens,
+  distributeEntryTokens,
+  distributeExitTokens,
   lpPK,
   swap,
   TestSetup,
-  ticketToL1Ticket,
+  ticketToEntryTicket,
   waitForTx,
 } from "./utils";
 
@@ -32,39 +32,39 @@ const tokenBalance = 1_000_000;
 const customerWallet = new ethers.Wallet(customerPK, ethers.provider);
 const lpWallet = new ethers.Wallet(lpPK, ethers.provider);
 
-const l1Deployer = new L1__factory(lpWallet);
-const l2Deployer = new L2__factory(lpWallet);
+const entryDeployer = new Entry__factory(lpWallet);
+const exitDeployer = new Exit__factory(lpWallet);
 const tokenDeployer = new TestToken__factory(lpWallet);
 let testSetup: TestSetup;
 
 beforeEach(async () => {
-  const l1Token = await tokenDeployer.deploy(tokenBalance);
-  const l2Token = await tokenDeployer.deploy(tokenBalance);
-  const l1 = await l1Deployer.deploy();
+  const entryToken = await tokenDeployer.deploy(tokenBalance);
+  const exitToken = await tokenDeployer.deploy(tokenBalance);
+  const entry = await entryDeployer.deploy();
 
-  const l2 = await l2Deployer.deploy();
+  const exit = await exitDeployer.deploy();
 
-  await l2.registerTokenPairs([
-    { l1Token: l1Token.address, l2Token: l2Token.address },
+  await exit.registerTokenPairs([
+    { entryToken: entryToken.address, exitToken: exitToken.address },
   ]);
-  const customerL2 = l2.connect(customerWallet);
+  const customerExit = exit.connect(customerWallet);
 
-  const lpL2 = l2.connect(lpWallet);
-  const lpL1 = l1.connect(lpWallet);
+  const lpExit = exit.connect(lpWallet);
+  const lpEntry = entry.connect(lpWallet);
 
   testSetup = {
-    lpL1,
-    lpL2,
+    lpEntry,
+    lpExit,
     lpWallet,
     gasLimit,
-    customerL2,
-    l1Token,
-    l2Token,
+    customerExit,
+    entryToken,
+    exitToken,
     customerWallet,
     tokenBalance,
   };
-  await distributeL1Tokens(testSetup);
-  await distributeL2Tokens(testSetup);
+  await distributeEntryTokens(testSetup);
+  await distributeExitTokens(testSetup);
 });
 
 it("One successfull e2e swaps", async () => {
@@ -86,34 +86,34 @@ it("Unable to authorize overlapping batches", async () => {
 it("Handles a fraud proofs", async () => {
   /**
    * Fraud instance 1. The liquidity provider signs a batch of tickets with the
-   * second ticket's l1Recipient switched to LP's address
+   * second ticket's entryRecipient switched to LP's address
    */
   await deposit(testSetup, 0, 10);
   await deposit(testSetup, 0, 10, customer2Address);
 
-  const { lpL2, customerL2 } = testSetup;
+  const { lpExit, customerExit } = testSetup;
 
   // Sign fraudulent batch
-  const ticket = await lpL2.tickets(0);
-  const ticket2 = await lpL2.tickets(1);
+  const ticket = await lpExit.tickets(0);
+  const ticket2 = await lpExit.tickets(1);
 
   await authorizeWithdrawal(testSetup, 0);
 
-  const fraudTicket = { ...ticket2, l1Recipient: lpWallet.address };
+  const fraudTicket = { ...ticket2, entryRecipient: lpWallet.address };
   const ticketsWithNonce: TicketsWithNonce = {
     startNonce: 0,
-    tickets: [ticket, fraudTicket].map(ticketToL1Ticket),
+    tickets: [ticket, fraudTicket].map(ticketToEntryTicket),
   };
   const fraudSignature = signData(hashTickets(ticketsWithNonce), lpPK);
 
   // Successfully prove fraud
   await waitForTx(
-    customerL2.refundOnFraud(
+    customerExit.refundOnFraud(
       0,
       1,
       0,
       1,
-      [ticket, fraudTicket].map(ticketToL1Ticket),
+      [ticket, fraudTicket].map(ticketToEntryTicket),
       fraudSignature,
       { gasLimit }
     )
@@ -121,12 +121,12 @@ it("Handles a fraud proofs", async () => {
 
   // Unsuccessfully try to claim fraud again
   await expect(
-    customerL2.refundOnFraud(
+    customerExit.refundOnFraud(
       0,
       1,
       0,
       1,
-      [ticket, fraudTicket].map(ticketToL1Ticket),
+      [ticket, fraudTicket].map(ticketToEntryTicket),
       fraudSignature,
       {
         gasLimit,
@@ -145,22 +145,22 @@ it("Handles a fraud proofs", async () => {
   await authorizeWithdrawal(testSetup, 2);
 
   // Sign fraudulent batch again
-  const ticket3 = await lpL2.tickets(1);
-  const ticket4 = await lpL2.tickets(2);
-  const fraudTicket2 = { ...ticket4, l1Recipient: lpWallet.address };
+  const ticket3 = await lpExit.tickets(1);
+  const ticket4 = await lpExit.tickets(2);
+  const fraudTicket2 = { ...ticket4, entryRecipient: lpWallet.address };
   const ticketsWithNonce2: TicketsWithNonce = {
     startNonce: 1,
-    tickets: [ticket3, fraudTicket2].map(ticketToL1Ticket),
+    tickets: [ticket3, fraudTicket2].map(ticketToEntryTicket),
   };
   const fraudSignature2 = signData(hashTickets(ticketsWithNonce2), lpPK);
 
   await waitForTx(
-    customerL2.refundOnFraud(
+    customerExit.refundOnFraud(
       2,
       0,
       1,
       1,
-      [ticket3, fraudTicket2].map(ticketToL1Ticket),
+      [ticket3, fraudTicket2].map(ticketToEntryTicket),
       fraudSignature2,
       { gasLimit }
     )
@@ -168,28 +168,28 @@ it("Handles a fraud proofs", async () => {
 });
 
 it("Able to get a ticket refunded", async () => {
-  const { customerL2 } = testSetup;
+  const { customerExit } = testSetup;
   await deposit(testSetup, 0, 10);
   await deposit(testSetup, 0, 10, customer2Address);
-  await expect(customerL2.refund(0, { gasLimit })).to.be.rejectedWith(
+  await expect(customerExit.refund(0, { gasLimit })).to.be.rejectedWith(
     "maxAuthDelay must have passed since deposit"
   );
 
   const delta = 5;
   await ethers.provider.send("evm_increaseTime", [MAX_AUTH_DELAY - delta]);
-  await expect(customerL2.refund(1, { gasLimit })).to.be.rejectedWith(
+  await expect(customerExit.refund(1, { gasLimit })).to.be.rejectedWith(
     "maxAuthDelay must have passed since deposit"
   );
   await ethers.provider.send("evm_increaseTime", [2 * delta]);
 
-  await waitForTx(customerL2.refund(0, { gasLimit }));
-  await waitForTx(customerL2.refund(1, { gasLimit }));
-  await expect(customerL2.refund(1, { gasLimit })).to.be.rejectedWith(
+  await waitForTx(customerExit.refund(0, { gasLimit }));
+  await waitForTx(customerExit.refund(1, { gasLimit }));
+  await expect(customerExit.refund(1, { gasLimit })).to.be.rejectedWith(
     "The nonce must not be a part of a batch"
   );
 
   await deposit(testSetup, 2, 8);
   await ethers.provider.send("evm_increaseTime", [MAX_AUTH_DELAY + delta]);
   // Refund 3rd and 4th deposit
-  await waitForTx(customerL2.refund(2, { gasLimit }));
+  await waitForTx(customerExit.refund(2, { gasLimit }));
 });


### PR DESCRIPTION
SAFE is a general swap technology that is particularly cost efficient for l2 to l1 swaps. As a result, both exit and enter contracts could be deployed on any chain or rollup.

`SAFE.md` is ignored for this rename as it needs a more manual edit than search/replace.