### PR TITLE
Tweak benchmarks for readability

### DIFF
--- a/test/entry-benchmarking.test.ts
+++ b/test/entry-benchmarking.test.ts
@@ -89,7 +89,7 @@ async function generateTickets(
 
 let testSetup: ToChainTestSetup;
 const tokens: Array<{ pair: TokenPairStruct; contract: TestToken }> = [];
-describe("to benchmarking", () => {
+describe("To Chain Benchmark", () => {
   beforeEach(async () => {
     const lpWallet = new ethers.Wallet(lpPK, ethers.provider);
     const customerWallet = new ethers.Wallet(customerPK, ethers.provider);

--- a/test/exit-benchmarking.test.ts
+++ b/test/exit-benchmarking.test.ts
@@ -47,29 +47,23 @@ export function printFromScenarioGasUsage(
       "Ticket Batch Size",
       "From Contract Function",
       "Total Gas",
-      "Average Gas Per Call",
+      "Average Gas Per Ticket",
       "Total Optimism L1 Fee",
-      "Average Optimism L1 Fee Per Call",
+      "Average Optimism L1 Fee Per Ticket",
     ],
     colAligns: ["right", "right", "right"],
   });
 
   for (const scenario of scenarios) {
-    const gasPerCall =
-      scenario.type === "depositOnFromChain"
-        ? scenario.totalGasUsed.div(scenario.batchSize)
-        : scenario.totalGasUsed;
-    const optimismCostPerCall =
-      scenario.type === "depositOnFromChain"
-        ? scenario.optimismCost.div(scenario.batchSize)
-        : scenario.optimismCost;
+    const gasPerCall = scenario.totalGasUsed.div(scenario.batchSize);
+    const optimismCostPerCall = scenario.optimismCost.div(scenario.batchSize);
     table.push([
       scenario.batchSize,
       scenario.type,
-      scenario.totalGasUsed.toNumber(),
-      gasPerCall.toNumber(),
-      scenario.optimismCost.toNumber(),
-      optimismCostPerCall.toNumber(),
+      scenario.totalGasUsed.toNumber().toLocaleString(),
+      gasPerCall.toNumber().toLocaleString(),
+      scenario.optimismCost.toNumber().toLocaleString(),
+      optimismCostPerCall.toNumber().toLocaleString(),
     ]);
   }
   console.log(table.toString());
@@ -160,7 +154,7 @@ async function runScenario(
 
 const tokens: Array<{ pair: TokenPairStruct; contract: TestToken }> = [];
 
-describe("from benchmarking", () => {
+describe("From Chain Benchmark", () => {
   beforeEach(async () => {
     const fromChain = await fromChainDeployer.deploy();
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -26,7 +26,7 @@ export type ScenarioGasUsage = {
 };
 
 export function printScenarioGasUsage(scenarios: ScenarioGasUsage[]) {
-  console.log("ToChain claimBatch Gas Usage");
+  console.log("To Chain claimBatch Gas Usage");
   const table = new Table({
     head: [
       "Ticket Batch Size",
@@ -48,10 +48,10 @@ export function printScenarioGasUsage(scenarios: ScenarioGasUsage[]) {
 
     table.push([
       scenario.batchSize,
-      averagePerClaim,
-      scenario.totalGasUsed,
-      scenario.optimismCost,
-      averageOptimismCost,
+      averagePerClaim.toLocaleString(),
+      scenario.totalGasUsed.toNumber().toLocaleString(),
+      scenario.optimismCost.toNumber().toLocaleString(),
+      averageOptimismCost.toLocaleString(),
     ]);
   }
   console.log(table.toString());


### PR DESCRIPTION
- Add decimal separators to benchmark numbers
- Change gas-per-call to gas-per-ticket